### PR TITLE
Port from GConf to Gio.Settings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+217
+* migrate from GConf to Gio.Settings (walter)
+
 216
 * conversion to GTK3 (zeecoder)
 * update repository field in activity.info

--- a/TurtleArt/tautils.py
+++ b/TurtleArt/tautils.py
@@ -21,7 +21,6 @@
 # THE SOFTWARE.
 
 import gi
-gi.require_version('GConf', '2.0')
 import tempfile
 import dbus
 import cairo
@@ -35,7 +34,7 @@ from gettext import gettext as _
 from gi.repository import Gtk
 from gi.repository import GObject
 from gi.repository import GdkPixbuf
-from gi.repository import GConf
+from gi.repository import Gio
 import json
 json.dumps
 from json import load as jload
@@ -959,12 +958,12 @@ def power_manager_off(status):
     OHM_SERVICE_IFACE = 'org.freedesktop.ohm.Keystore'
     PATH = '/etc/powerd/flags/inhibit-suspend'
 
-    client = GConf.Client.get_default()
+    settings = Gio.Settings('org.sugarlabs.power');
 
     ACTUAL_POWER = True
 
     if FIRST_TIME:
-        ACTUAL_POWER = client.get_bool('/desktop/sugar/power/automatic')
+        ACTUAL_POWER = settings.get_bool('automatic')
         FIRST_TIME = False
 
     if status:
@@ -972,10 +971,7 @@ def power_manager_off(status):
     else:
         VALUE = ACTUAL_POWER
 
-    try:
-        client.set_bool('/desktop/sugar/power/automatic', VALUE)
-    except GConf.GError:
-        pass
+    settings.set_bool('automatic', VALUE)
 
     bus = dbus.SystemBus()
     try:

--- a/TurtleArt/tawindow.py
+++ b/TurtleArt/tawindow.py
@@ -441,12 +441,14 @@ class TurtleArtWindow():
             # add icons paths of all plugins
             self._add_plugin_icon_dir(os.path.join(plugin_path, plugin_dir))
             status = True
-            if not self.running_sugar and hasattr(self.activity, 'client'):
-                gconf_path = self.activity._PLUGINS_PATH + plugin_dir
-                try:
-                    status = (self.activity.client.get_int(gconf_path) == 1)
-                except BaseException:
-                    pass
+            if not self.running_sugar and hasattr(self.activity, '_settings'):
+                plugins_list = self.activity._settings.get_string(self.activity._PLUGINS_LIST)
+                plugins = plugins_list.split(',')
+                if plugin_dir in plugins:
+                    status = 1
+                else:
+                    status = 0
+
                 make_checkmenu_item(
                     self.activity._plugin_menu,
                     plugin_dir,

--- a/TurtleArt/turtleblocks.py
+++ b/TurtleArt/turtleblocks.py
@@ -139,7 +139,7 @@ class TurtleMain():
         """ return an activity-specific Gio.Settings
         """
         # create schemas directory if missing
-        path = os.path.join(activity_root, 'schemas')
+        path = os.path.join(get_path(None, 'data'), 'schemas')
         if not os.access(path, os.F_OK):
             os.makedirs(path)
 

--- a/TurtleArt/turtleblocks.py
+++ b/TurtleArt/turtleblocks.py
@@ -38,6 +38,8 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject
 from gi.repository import GdkPixbuf
+from gi.repository import Gio
+
 try:
     # Try to use XDG Base Directory standard for config files.
     import xdg.BaseDirectory
@@ -76,13 +78,14 @@ class TurtleMain():
         '/usr/local/share/sugar/activities/TurtleArt.activity'
     _ICON_SUBPATH = 'images/turtle.png'
     _GNOME_PLUGIN_SUBPATH = 'gnome_plugins'
-    _HOVER_HELP = '/desktop/sugar/activities/turtleart/hoverhelp'
-    _ORIENTATION = '/desktop/sugar/activities/turtleart/orientation'
-    _COORDINATE_SCALE = '/desktop/sugar/activities/turtleart/coordinatescale'
-    _PLUGINS_PATH = '/desktop/sugar/activities/turtleart/plugins/'
+    _GIO_SETTINGS = 'org.laptop.TurtleArtActivity'
+    _HOVER_HELP = 'hover-help'
+    _ORIENTATION = 'palette-orientation'
+    _COORDINATE_SCALE = 'coordinate-scale'
+    _PLUGINS_LIST = 'plugins'
 
     def __init__(self, lib_path, share_path):
-        self._setting_gconf_overrides = False
+        self._gio_settings_overrides = False
 
         self._lib_path = lib_path
         self._share_path = share_path
@@ -126,18 +129,37 @@ class TurtleMain():
         else:
             self._read_initial_pos()
             self._init_gnome_plugins()
-            self._get_gconf_settings()
+            self._get_gio_settings()
             self._setup_gtk()
             self._build_window()
             self._run_gnome_plugins()
             self._start_gtk()
 
-    def _get_gconf_settings(self):
-        try:
-            from gi.repository import GConf
-            self.client = GConf.Client.get_default()
-        except ImportError:
-            pass
+    def _get_local_settings(self, activity_root):
+        """ return an activity-specific Gio.Settings
+        """
+        # create schemas directory if missing
+        path = os.path.join(activity_root, 'schemas')
+        if not os.access(path, os.F_OK):
+            os.makedirs(path)
+
+        # create compiled schema file if missing
+        compiled = os.path.join(path, 'gschemas.compiled')
+        if not os.access(compiled, os.R_OK):
+            src = '%s.gschema.xml' % self._GIO_SETTINGS
+            lines = open(os.path.join(activity_root, src), 'r').readlines()
+            open(os.path.join(path, src), 'w').writelines(lines)
+            os.system('glib-compile-schemas %s' % path)
+            os.remove(os.path.join(path, src))
+
+        # create a local Gio.Settings based on the compiled schema
+        source = Gio.SettingsSchemaSource.new_from_directory(path, None, True)
+        schema = source.lookup(self._GIO_SETTINGS, True)
+        _settings = Gio.Settings.new_full(schema, None, None)
+        return _settings
+
+    def _get_gio_settings(self):
+        self._settings = self._get_local_settings(self._share_path)
 
     def get_config_home(self):
         return CONFIG_HOME
@@ -204,7 +226,7 @@ return %s(self)" % (p, P, P)
         else:
             self.win.get_window().set_cursor(Gdk.Cursor(Gdk.CursorType.WATCH))
             GObject.idle_add(self._project_loader, self._ta_file)
-        self._set_gconf_overrides()
+        self._set_gio_settings_overrides()
         Gtk.main()
 
     def _project_loader(self, file_name):
@@ -255,29 +277,29 @@ return %s(self)" % (p, P, P)
             running_sugar=False)
         self.tw.save_folder = self._abspath  # os.path.expanduser('~')
 
-        if hasattr(self, 'client'):
-            if self.client.get_int(self._HOVER_HELP) == 1:
+        if hasattr(self, '_settings'):
+            if self._settings.get_int(self._HOVER_HELP) == 1:
                 self.tw.no_help = True
                 self.hover.set_active(False)
                 self._do_hover_help_off_cb()
-            if not self.client.get_int(self._COORDINATE_SCALE) in [0, 1]:
+            if not self._settings.get_int(self._COORDINATE_SCALE) in [0, 1]:
                 self.tw.coord_scale = 1
             else:
                 self.tw.coord_scale = 0
-            if self.client.get_int(self._ORIENTATION) == 1:
+            if self._settings.get_int(self._ORIENTATION) == 1:
                 self.tw.orientation = 1
         else:
             self.tw.coord_scale = 0
 
-    def _set_gconf_overrides(self):
+    def _set_gio_settings_overrides(self):
         if self.tw.coord_scale == 0:
             self.tw.coord_scale = 1
         else:
             self._do_rescale_cb(None)
         if self.tw.coord_scale != 1:
-            self._setting_gconf_overrides = True
+            self._gio_settings_overrides = True
             self.coords.set_active(True)
-            self._setting_gconf_overrides = False
+            self._gio_settings_overrides = False
 
     def _init_vars(self):
         ''' If we are invoked to start a project from Gnome, we should make
@@ -553,8 +575,8 @@ return %s(self)" % (p, P, P)
             elif resp == Gtk.ResponseType.CANCEL:
                 return
 
-        if hasattr(self, 'client'):
-            self.client.set_int(self._ORIENTATION, self.tw.orientation)
+        if hasattr(self, '_settings'):
+            self._settings.set_int(self._ORIENTATION, self.tw.orientation)
 
         for plugin in self.tw.turtleart_plugins.values():
             if hasattr(plugin, 'quit'):
@@ -769,7 +791,7 @@ Would you like to save before quitting?'))
 
     def _do_rescale_cb(self, button):
         ''' Callback to rescale coordinate space. '''
-        if self._setting_gconf_overrides:
+        if self._gio_settings_overrides:
             return
         if self.tw.coord_scale == 1:
             self.tw.coord_scale = self.tw.height / 40
@@ -793,9 +815,9 @@ Would you like to save before quitting?'))
             default_values['arc'] = [90, 100]
             default_values['setpensize'] = [5]
             self.tw.turtles.get_active_turtle().set_pen_size(5)
-        if hasattr(self, 'client'):
-            self.client.set_int(self._COORDINATE_SCALE,
-                                int(self.tw.coord_scale))
+        if hasattr(self, '_settings'):
+            self._settings.set_int(self._COORDINATE_SCALE,
+                                   int(self.tw.coord_scale))
 
         self.tw.recalculate_constants()
 
@@ -809,33 +831,37 @@ Would you like to save before quitting?'))
 
     def _do_toggle_plugin_cb(self, button):
         name = button.get_label()
-        path_gconf = self._PLUGINS_PATH + name
-        if button.get_active():
-            #path = self.tw.turtleart_plugin_list[name]
-            #self.tw.init_plugin(name, path)
-            #instance = self.tw._get_plugin_instance(name)
-            # instance.setup()
-            self.client.set_int(path_gconf, 1)
-            l = _('Please restart %s in order to use the plugin.') % self.name
-        else:
-            #instance = self.tw._get_plugin_instance(name)
-            # instance.quit()
-            self.client.set_int(path_gconf, 0)
-            l = _('Please restart %s in order to unload the plugin.') % self.name
-        self.tw.showlabel('status', l)
+        if hasattr(self, '_settings'):
+            plugins_list = self._settings.get_string(self._PLUGINS_LIST)
+            plugins = plugins_list.split(',')
+            if button.get_active():
+                if not name in plugins:
+                    plugins.append(name)
+                    self._settings.set_string(
+                        self._PLUGINS_LIST, ','.join(plugins))
+                label = _('Please restart %s in order to use the plugin.') \
+                        % self.name
+            else:
+                if name in plugins:
+                    plugins.remove(name)
+                    self._settings.set_string(
+                        self._PLUGINS_LIST, ','.join(plugins))
+                label = _('Please restart %s in order to unload the plugin.') \
+                        % self.name
+        self.tw.showlabel('status', label)
 
     def _do_hover_help_on_cb(self):
         ''' Turn hover help on '''
-        if hasattr(self, 'client'):
-            self.client.set_int(self._HOVER_HELP, 0)
+        if hasattr(self, '_settings'):
+            self._settings.set_int(self._HOVER_HELP, 0)
 
     def _do_hover_help_off_cb(self):
         ''' Turn hover help off '''
         self.tw.last_label = None
         if self.tw.status_spr is not None:
             self.tw.status_spr.hide()
-        if hasattr(self, 'client'):
-            self.client.set_int(self._HOVER_HELP, 1)
+        if hasattr(self, '_settings'):
+            self._settings.set_int(self._HOVER_HELP, 1)
 
     def _do_palette_cb(self, widget):
         ''' Callback to show/hide palette of blocks. '''

--- a/TurtleArtActivity.py
+++ b/TurtleArtActivity.py
@@ -147,7 +147,7 @@ class TurtleArtActivity(activity.Activity):
         # Now called from lazy_init
         # self.check_buttons_for_fit()
 
-        self._settings = self._get_local_settings()
+        self._settings = self._get_local_settings(activity.get_activity_root())
         if self._settings.get_int(self._HOVER_HELP) == 1:
             self._do_hover_help_toggle(None)
         if self._settings.get_int(self._COORDINATE_SCALE) not in [0, 1]:
@@ -162,11 +162,11 @@ class TurtleArtActivity(activity.Activity):
 
         self.init_complete = True
 
-    def _get_local_settings(self):
+    def _get_local_settings(self, activity_root):
         """ return an activity-specific Gio.Settings
         """
         # create schemas directory if missing
-        path = os.path.join(self.bundle_path, 'schemas')
+        path = os.path.join(activity_root, 'data', 'schemas')
         if not os.access(path, os.F_OK):
             os.makedirs(path)
 

--- a/activity/activity.info
+++ b/activity/activity.info
@@ -1,6 +1,6 @@
 [Activity]
 name = TurtleBlocks
-activity_version = 216
+activity_version = 217
 license = MIT
 bundle_id = org.laptop.TurtleArtActivity
 exec = sugar-activity TurtleArtActivity.TurtleArtActivity

--- a/collaboration/buddy.py
+++ b/collaboration/buddy.py
@@ -17,7 +17,6 @@
 
 import logging
 
-from gi.repository import GConf
 import dbus
 from telepathy.client import Connection
 from telepathy.interfaces import CONNECTION
@@ -94,10 +93,7 @@ class OwnerBuddyModel(BaseBuddyModel):
     def __init__(self):
         BaseBuddyModel.__init__(self)
 
-        # client = gconf.client_get_default()
-        # self.props.nick = client.get_string('/desktop/sugar/user/nick')
         self.props.nick = "rgs"
-        # color = client.get_string('/desktop/sugar/user/color')
         self.props.color = XoColor(None)
 
         # self.props.key = get_profile().pubkey

--- a/collaboration/xocolor.py
+++ b/collaboration/xocolor.py
@@ -22,7 +22,7 @@ STABLE.
 import random
 import logging
 
-from gi.repository import GConf
+from gi.repository import Gio
 
 colors = [
     ['#B20008', '#FF2B34'],
@@ -236,8 +236,8 @@ class XoColor:
         elif not is_valid(color_string):
             logging.debug('Color string is not valid: %s, '
                           'fallback to default', color_string)
-            client = GConf.Client.get_default()
-            color_string = client.get_string('/desktop/sugar/user/color')
+            settings = Gio.Settings('org.sugarlabs.user')
+            color_string = settings.get_string('color')
             randomize = False
         else:
             randomize = False

--- a/org.laptop.TurtleArtActivity.gschema.xml
+++ b/org.laptop.TurtleArtActivity.gschema.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+    <schema id="org.laptop.TurtleArtActivity" path="/org/laptop/TurtleArtActivity/">
+        <key name="hover-help" type="i">
+            <default>0</default>
+            <summary>hover help status</summary>
+            <description>Hover help can be turned off (on by default).</description>
+        </key>
+        <key name="palette-orientation" type="i">
+            <default>1</default>
+            <summary>palette orientation status</summary>
+            <description>The palettes can be either horizontal or vertical.</description>
+        </key>
+        <key name="coordinate-scale" type="i">
+            <default>1</default>
+            <summary>coordinate-scale status</summary>
+            <description>Coordinates can be scaled from 0-100 or by pixels.</description>
+        </key>
+        <key name="plugins" type="s">
+            <default>''</default>
+            <summary>plugin status</summary>
+            <description>A list of plugins that have been loaded.</description>
+        </key>
+    </schema>
+</schemalist>


### PR DESCRIPTION
Turtle Art used GConf to read and store settings.
GConf is no longer available.

- remove GConf,
- rely on Gio.Settings instead.

For the activity-specific settings, use a local Gio.SettingsSchemaSource, compile the schema on first start, and store the changed value in the Gio.Settings.

- plugins are managed by a CSV string: any plugins that are loaded are included in the string.

The version has been bumped up to 217.