### PR TITLE
Partial fix to running in non-interactive mode

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+218
+* fix problem with Gio.Settings in cmdline version (walter)
+* fix problem with -o from  cmdline version (walter)
+* fix problem with line cap (walter)
+* fix problem with fullscreen/unfullscreen (walter)
+* fix numerous problems with file save buttons (walter)
+* fix import require warning (walter)
+
 217
 * migrate from GConf to Gio.Settings (walter)
 

--- a/TurtleArt/sprites.py
+++ b/TurtleArt/sprites.py
@@ -78,6 +78,7 @@ def svg_str_to_pixbuf(svg_string):
 import cairo
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version('PangoCairo', '1.0')
 
 from gi.repository import Gtk
 from gi.repository import Gdk

--- a/TurtleArt/tacanvas.py
+++ b/TurtleArt/tacanvas.py
@@ -366,6 +366,7 @@ class TurtleGraphics:
         ''' Draw a line '''
 
         def _draw_line(cr, x1, y1, x2, y2):
+            cr.set_line_cap(1)  # Set the line cap to be round
             cr.move_to(x1, y1)
             cr.line_to(x2, y2)
             cr.stroke()

--- a/TurtleArt/tautils.py
+++ b/TurtleArt/tautils.py
@@ -413,7 +413,7 @@ def do_dialog(dialog, suffix, load_save_folder):
         dialog.set_current_folder(load_save_folder)
 
     response = dialog.run()
-    if response == Gtk.ResponseType:
+    if response == Gtk.ResponseType.OK:
         result = dialog.get_filename()
         load_save_folder = dialog.get_current_folder()
     dialog.destroy()

--- a/TurtleArt/tautils.py
+++ b/TurtleArt/tautils.py
@@ -963,7 +963,7 @@ def power_manager_off(status):
     ACTUAL_POWER = True
 
     if FIRST_TIME:
-        ACTUAL_POWER = settings.get_bool('automatic')
+        ACTUAL_POWER = settings.get_boolean('automatic')
         FIRST_TIME = False
 
     if status:

--- a/TurtleArt/tawindow.py
+++ b/TurtleArt/tawindow.py
@@ -3013,11 +3013,12 @@ class TurtleArtWindow():
             if len(self.block_list.get_similar_blocks('block', 'forever')) > 0:
                 debug_output('WARNING: Projects with forever blocks \
  may not terminate.', False)
+            self.__run_stack(blk)
         else:
             self._hide_text_entry()
             self.parent.get_window().set_cursor(
                 Gdk.Cursor(Gdk.CursorType.WATCH))
-        GObject.idle_add(self.__run_stack, blk)
+            GObject.idle_add(self.__run_stack, blk)
 
     def __run_stack(self, blk):
         if self.status_spr is not None:
@@ -3025,7 +3026,8 @@ class TurtleArtWindow():
         self._autohide_shape = True
         if blk is None:
             return
-        self.lc.find_value_blocks()  # Are there blocks to update?
+        if not self.interactive_mode:
+            self.lc.find_value_blocks()  # Are there blocks to update?
         if self.canvas.cr_svg is None:
             self.canvas.setup_svg_surface()
         self.running_blocks = True
@@ -4395,6 +4397,8 @@ class TurtleArtWindow():
 
     def display_coordinates(self, clear=False):
         ''' Display the coordinates of the current turtle on the toolbar '''
+        if not self.interactive_mode:
+            return
         if clear:
             self._set_coordinates_label('')
         else:

--- a/TurtleArt/tawindow.py
+++ b/TurtleArt/tawindow.py
@@ -31,6 +31,8 @@ import subprocess
 import errno
 from gettext import gettext as _
 
+import cairo
+
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject

--- a/TurtleArt/tawindow.py
+++ b/TurtleArt/tawindow.py
@@ -857,6 +857,8 @@ class TurtleArtWindow():
         if self.running_sugar:
             self.activity.fullscreen()
             self.activity.recenter()
+            self.activity.vbox.set_size_request(Gdk.Screen.width(),
+                                                Gdk.Screen.height())
 
     def set_cartesian(self, flag):
         ''' Turn on/off Cartesian coordinates '''
@@ -3656,6 +3658,9 @@ class TurtleArtWindow():
             # Always exit fullscreen mode if applicable
             if self.running_sugar and self.activity.is_fullscreen:
                 self.activity.unfullscreen()
+                self.vbox.set_size_request(Gdk.Screen.width(),
+                                           Gdk.Screen.height() -
+                                           2 * style.GRID_CELL_SIZE)
         return True
 
     def _jog_turtle(self, dx, dy):

--- a/TurtleArt/tawindow.py
+++ b/TurtleArt/tawindow.py
@@ -441,19 +441,18 @@ class TurtleArtWindow():
             # add icons paths of all plugins
             self._add_plugin_icon_dir(os.path.join(plugin_path, plugin_dir))
             status = True
-            if not self.running_sugar and hasattr(self.activity, '_settings'):
-                plugins_list = self.activity._settings.get_string(self.activity._PLUGINS_LIST)
-                plugins = plugins_list.split(',')
-                if plugin_dir in plugins:
-                    status = 1
-                else:
-                    status = 0
-
-                make_checkmenu_item(
-                    self.activity._plugin_menu,
-                    plugin_dir,
-                    self.activity._do_toggle_plugin_cb,
-                    status)
+            if not self.running_sugar and hasattr(self.activity, 'client'):
+                gconf_path = self.activity._PLUGINS_PATH + plugin_dir
+                try:
+                    status = (self.activity.client.get_int(gconf_path) == 1)
+                except BaseException:
+                    pass
+                if hasattr(self.activity, '_plugin_menu'):
+                    make_checkmenu_item(
+                        self.activity._plugin_menu,
+                        plugin_dir,
+                        self.activity._do_toggle_plugin_cb,
+                        status)
             if status:
                 self.init_plugin(plugin_dir, plugin_path)
                 self.turtleart_favorites_plugins.append(plugin_dir)

--- a/TurtleArt/turtleblocks.py
+++ b/TurtleArt/turtleblocks.py
@@ -289,7 +289,7 @@ return %s(self)" % (p, P, P)
             if self._settings.get_int(self._ORIENTATION) == 1:
                 self.tw.orientation = 1
         else:
-            self.tw.coord_scale = 0
+            self.tw.coord_scale = 1
 
     def _set_gio_settings_overrides(self):
         if self.tw.coord_scale == 0:

--- a/TurtleArt/turtleblocks.py
+++ b/TurtleArt/turtleblocks.py
@@ -277,8 +277,8 @@ return %s(self)" % (p, P, P)
             running_sugar=False)
         self.tw.save_folder = self._abspath  # os.path.expanduser('~')
 
-        if interactive and hasattr(self, 'client'):
-            if self.client.get_int(self._HOVER_HELP) == 1:
+        if interactive:
+            if self._settings.get_int(self._HOVER_HELP) == 1:
                 self.tw.no_help = True
                 self.hover.set_active(False)
                 self._do_hover_help_off_cb()

--- a/TurtleArt/turtleblocks.py
+++ b/TurtleArt/turtleblocks.py
@@ -124,6 +124,7 @@ class TurtleMain():
         if self._output_png:
             # Outputing to file, so no need for a canvas
             self.canvas = None
+            self._get_gconf_settings()
             self._build_window(interactive=False)
             self._draw_and_quit()
         else:
@@ -241,7 +242,7 @@ return %s(self)" % (p, P, P)
         and quit. '''
         self.tw.load_start(self._ta_file)
         self.tw.lc.trace = 0
-        self.tw.run_button(0)
+        self.tw.run_button(0, running_from_button_push=True)
         self.tw.save_as_image(self._ta_file)
 
     def _build_window(self, interactive=True):
@@ -267,7 +268,6 @@ return %s(self)" % (p, P, P)
             self._autosavedirname = self._share_path
         else:
             self._autosavedirname = os.path.expanduser('~')
-
         self.tw = TurtleArtWindow(
             self.canvas,
             self._lib_path,
@@ -277,8 +277,8 @@ return %s(self)" % (p, P, P)
             running_sugar=False)
         self.tw.save_folder = self._abspath  # os.path.expanduser('~')
 
-        if hasattr(self, '_settings'):
-            if self._settings.get_int(self._HOVER_HELP) == 1:
+        if interactive and hasattr(self, 'client'):
+            if self.client.get_int(self._HOVER_HELP) == 1:
                 self.tw.no_help = True
                 self.hover.set_active(False)
                 self._do_hover_help_off_cb()

--- a/TurtleArtActivity.py
+++ b/TurtleArtActivity.py
@@ -267,7 +267,7 @@ class TurtleArtActivity(activity.Activity):
 
     def do_save_as_python_cb(self, widget):
         ''' Callback for saving the project as Python code. '''
-        self.save_as_python.set_icon('python-saveon')
+        self.save_as_python[0].set_icon('python-saveon')
         if hasattr(self, 'get_window'):
             if hasattr(self.get_window(), 'get_cursor'):
                 self._old_cursor = self.get_window().get_cursor()
@@ -395,7 +395,7 @@ class TurtleArtActivity(activity.Activity):
 
     def do_save_as_image_cb(self, button):
         ''' Save the canvas to the Journal. '''
-        self.save_as_image.set_icon_name('image-saveon')
+        self.save_as_image[0].set_icon_name('image-saveon')
         _logger.debug('saving image to journal')
         if hasattr(self, 'get_window'):
             if hasattr(self.get_window(), 'get_cursor'):
@@ -405,7 +405,7 @@ class TurtleArtActivity(activity.Activity):
 
     def __save_as_image(self):
         self.tw.save_as_image()
-        self.save_as_image.set_icon_name('image-saveoff')
+        self.save_as_image[0].set_icon_name('image-saveoff')
         if hasattr(self, 'get_window'):
             self.get_window().set_cursor(self._old_cursor)
 
@@ -416,7 +416,7 @@ class TurtleArtActivity(activity.Activity):
             if hasattr(self.get_window(), 'get_cursor'):
                 self._old_cursor = self.get_window().get_cursor()
                 self.get_window().set_cursor(Gdk.Cursor(Gdk.CursorType.WATCH))
-        Gobject.timeout_add(250, self.__save_blocks_as_image)
+        GObject.timeout_add(250, self.__save_blocks_as_image)
 
     def __save_blocks_as_image(self):
         self.tw.save_blocks_as_image()

--- a/TurtleArtActivity.py
+++ b/TurtleArtActivity.py
@@ -623,6 +623,15 @@ class TurtleArtActivity(activity.Activity):
         ''' Hide the Sugar toolbars. '''
         self.fullscreen()
         self.recenter()
+        self.vbox.set_size_request(Gdk.Screen.width(), Gdk.Screen.height())
+
+    def do_unfullscreen_cb(self, button):
+        ''' Show the Sugar toolbars. '''
+        self.unfullscreen()
+        self.recenter()
+        self.vbox.set_size_request(Gdk.Screen.width(),
+                                   Gdk.Screen.height() -
+                                   2 * style.GRID_CELL_SIZE)
 
     def do_grow_blocks_cb(self, button):
         ''' Grow the blocks. '''
@@ -853,6 +862,8 @@ class TurtleArtActivity(activity.Activity):
         self.edit_toolbar_button.set_expanded(True)
         self.edit_toolbar_button.set_expanded(False)
         self.palette_toolbar_button.set_expanded(True)
+
+        self._unfullscreen_button._button.connect('clicked', self.do_unfullscreen_cb)
 
     def _setup_extra_controls(self):
         ''' Add the rest of the buttons to the main toolbar '''

--- a/TurtleArtActivity.py
+++ b/TurtleArtActivity.py
@@ -1103,9 +1103,7 @@ class TurtleArtActivity(activity.Activity):
         _logger.debug('overflow palette cb')
         if self._overflow_palette:
             if not self._overflow_palette.is_up():
-                self._overflow_palette.popup(
-                    immediate=True,
-                    state=self._overflow_palette.SECONDARY)
+                self._overflow_palette.popup(immediate=True)
             else:
                 self._overflow_palette.popdown(immediate=True)
             return
@@ -1194,7 +1192,7 @@ class TurtleArtActivity(activity.Activity):
         palette = button.get_palette()
         if palette:
             if not palette.is_up():
-                palette.popup(immediate=True, state=palette.SECONDARY)
+                palette.popup(immediate=True)
             else:
                 palette.popdown(immediate=True)
 

--- a/TurtleArtActivity.py
+++ b/TurtleArtActivity.py
@@ -267,7 +267,7 @@ class TurtleArtActivity(activity.Activity):
 
     def do_save_as_python_cb(self, widget):
         ''' Callback for saving the project as Python code. '''
-        self.save_as_python[0].set_icon('python-saveon')
+        self.save_as_python.set_icon_name('python-saveon')
         if hasattr(self, 'get_window'):
             if hasattr(self.get_window(), 'get_cursor'):
                 self._old_cursor = self.get_window().get_cursor()
@@ -395,7 +395,7 @@ class TurtleArtActivity(activity.Activity):
 
     def do_save_as_image_cb(self, button):
         ''' Save the canvas to the Journal. '''
-        self.save_as_image[0].set_icon_name('image-saveon')
+        self.save_as_image.set_icon_name('image-saveon')
         _logger.debug('saving image to journal')
         if hasattr(self, 'get_window'):
             if hasattr(self.get_window(), 'get_cursor'):
@@ -405,7 +405,7 @@ class TurtleArtActivity(activity.Activity):
 
     def __save_as_image(self):
         self.tw.save_as_image()
-        self.save_as_image[0].set_icon_name('image-saveoff')
+        self.save_as_image.set_icon_name('image-saveoff')
         if hasattr(self, 'get_window'):
             self.get_window().set_cursor(self._old_cursor)
 
@@ -553,8 +553,8 @@ class TurtleArtActivity(activity.Activity):
             self.stop_turtle_button.set_tooltip(_('Hide blocks'))
         # Note: We leave the old button state highlighted to indicate
         # speed if blocks are clicked to run.
-        # self.run_button.set_icon('run-fastoff')
-        # self.step_button.set_icon('run-slowoff')
+        # self.run_button.set_icon_name('run-fastoff')
+        # self.step_button.set_icon_name('run-slowoff')
         self.tw.stop_button()
         self.tw.display_coordinates()
 
@@ -1121,21 +1121,21 @@ class TurtleArtActivity(activity.Activity):
             toolbar)
         self._save_palette = save_button.get_palette()
         button_box = Gtk.VBox()
-        self.save_as_image = self._add_button_and_label(
+        self.save_as_image, label = self._add_button_and_label(
             'image-saveoff', _('Save as image'), self.do_save_as_image_cb,
             None, button_box)
-        self.save_as_icon = self._add_button_and_label(
+        self.save_as_icon, label = self._add_button_and_label(
             'image-saveoff', _('Save as icon'), self.do_save_as_icon_cb,
             None, button_box)
         # TRANS: ODP is Open Office presentation
-        self.save_as_odp = self._add_button_and_label(
+        self.save_as_odp, label = self._add_button_and_label(
             'odp-saveoff', _('Save as ODP'), self.do_save_as_odp_cb,
             None, button_box)
-        self.save_as_icon[0].get_parent().connect(
+        self.save_as_icon.get_parent().connect(
             'draw',
             self._save_as_icon_expose_cb)
 
-        self.save_as_odp[0].get_parent().connect(
+        self.save_as_odp.get_parent().connect(
             'draw',
             self._save_as_odp_expose_cb)
 

--- a/activity/activity.info
+++ b/activity/activity.info
@@ -1,6 +1,6 @@
 [Activity]
 name = TurtleBlocks
-activity_version = 217
+activity_version = 218
 license = MIT
 bundle_id = org.laptop.TurtleArtActivity
 exec = sugar-activity TurtleArtActivity.TurtleArtActivity


### PR DESCRIPTION
* Plugin code requires access to GConf client, even in non-interactive mode
* Don't try setting plugin menu in non-interactive mode
* Run from "button press"

These patches are related to https://github.com/sugarlabs/turtleart-activity/issues/30 After applying these patches, the output is now created, but several problems remain:
(1) in non-interactive mode, the output is created, but it is blank, even though the code is run
(2) in interactive mode, the filename returned from the file selector is blank, so no output is created