### PR TITLE
Reverse interactive mode test in __run_stack

### DIFF
--- a/TurtleArt/tawindow.py
+++ b/TurtleArt/tawindow.py
@@ -3032,7 +3032,7 @@ class TurtleArtWindow():
         self._autohide_shape = True
         if blk is None:
             return
-        if not self.interactive_mode:
+        if self.interactive_mode:
             self.lc.find_value_blocks()  # Are there blocks to update?
         if self.canvas.cr_svg is None:
             self.canvas.setup_svg_surface()


### PR DESCRIPTION
Walter said;

> you do not want to find value blocks in non-interactive mode

See also

https://github.com/sugarlabs/activity-turtle-confusion/pull/4/commits/ebd529bcb4632fe0a6a8191f9587e1dab892d3e6

https://github.com/sugarlabs/activity-turtle-confusion/pull/4

Reported-by: Yash Agrawal <yagrawal900@gmail.com>
Signed-off-by: James Cameron <quozl@laptop.org>