### PR TITLE
Further improve appdata compliance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,17 @@ def generate_appdata(prefix, bundle_id):
     for version, date in release_pairs:
         ET.SubElement(releases_root, 'release', date=date, version=version)
 
+    license_map = {
+      'GPLv2+': 'GPL-2.0-or-later',
+      'GPLv3+': 'GPL-3.0-or-later',
+      'LGPLv2+': 'LGPL-2.0-or-later',
+      'LGPLv2.1+': 'LGPL-2.1-or-later',
+    }
+    licenses = info.get('Activity', 'license').split(';')
+    spdx_licenses = map(lambda x: license_map.get(x, x), licenses)
+    ET.SubElement(root, 'project_license').text = " AND ".join(spdx_licenses)
+
     copy_pairs = [('metadata_license', 'metadata_license'),
-                  ('license', 'project_license'),
                   ('summary', 'summary'),
                   ('name', 'name')]
     for key, ename in copy_pairs:

--- a/setup.py
+++ b/setup.py
@@ -66,13 +66,13 @@ def generate_appdata(prefix, bundle_id):
         ET.SubElement(root, ename).text = info.get('Activity', key)
 
     if info.has_option('Activity', 'screenshots'):
-        screenshots = info.get('Activity', 'screenshots').split()
+        screenshots = info.get('Activity', 'screenshots').split(',')
         ss_root = ET.SubElement(root, 'screenshots')
         for i, screenshot in enumerate(screenshots):
             e = ET.SubElement(ss_root, 'screenshot')
             if i == 0:
                 e.set('type', 'default')
-            ET.SubElement(e, 'image').text = screenshot
+            ET.SubElement(e, 'image').text = screenshot.strip()
 
     if info.has_option('Activity', 'url'):
         ET.SubElement(root, 'url', type='homepage').text = \


### PR DESCRIPTION
Looks like flathub is stricter than before and now refuses to build with these minor appdata problems.

```
builddir/files/share/appdata/org.laptop.TurtleArtActivity.appdata.xml: FAILED:
• tag-invalid           : <project_license> is not valid [MIT;GPLv2+;LGPLv2+;LGPLv2.1+;GPLv3+]SPDX ID 'MIT;GPLv2+;LGPLv2+;LGPLv2.1+;GPLv3+' unknown
• url-not-found         : <screenshot> failed to download (HTTP 404: Not Found) [https://raw.githubusercontent.com/sugarlabs/turtleart-activity/master/screenshots/1.png,]
• url-not-found         : <screenshot> failed to download (HTTP 404: Not Found) [https://raw.githubusercontent.com/sugarlabs/turtleart-activity/master/screenshots/2.png,]
```
