### PR TITLE
bypass unneeded Sugar imports

### DIFF
--- a/TurtleArt/taexportlogo.py
+++ b/TurtleArt/taexportlogo.py
@@ -19,7 +19,11 @@
 # THE SOFTWARE.
 
 
-from sugar3.datastore import datastore
+try:
+    from sugar3.datastore import datastore
+except ImportError:
+    datastore = None
+
 from TurtleArt.tapalette import (logo_commands, logo_functions)
 from TurtleArt.taconstants import (TITLEXY, CONSTANTS)
 
@@ -123,8 +127,7 @@ def save_logo(tw):
 
 
 def _add_label(string):
-    if isinstance(string, str) and string[0:8] in ['#smedia_', '#saudio_',
-                                                   '#svideo_', '#sdescr_']:
+    if datastore is not None and isinstance(string, str) and string[0:8] in ['#smedia_', '#saudio_', '#svideo_', '#sdescr_']:
         string = string[8:]
         dsobject = datastore.get(string[8:])
         if 'title' in dsobject.metadata:

--- a/TurtleArt/taexportlogo.py
+++ b/TurtleArt/taexportlogo.py
@@ -24,8 +24,8 @@ try:
 except ImportError:
     datastore = None
 
-from TurtleArt.tapalette import (logo_commands, logo_functions)
-from TurtleArt.taconstants import (TITLEXY, CONSTANTS)
+from TurtleArt.tapalette import logo_commands, logo_functions
+from TurtleArt.taconstants import TITLEXY, CONSTANTS
 
 
 def save_logo(tw):
@@ -33,44 +33,46 @@ def save_logo(tw):
 
     # We need to catch several special cases: stacks, boxes, labels, etc.
     dispatch_table = {
-        'label': _add_label,
-        'to action': _add_named_stack,
-        'action': _add_reference_to_stack,
-        'storeinbox': _add_named_box,
-        'box': _add_reference_to_box}
+        "label": _add_label,
+        "to action": _add_named_stack,
+        "action": _add_reference_to_stack,
+        "storeinbox": _add_named_box,
+        "box": _add_reference_to_box,
+    }
     constants_table = {
-        'lpos': _lpos,
-        'tpos': _tpos,
-        'rpos': _rpos,
-        'bpos': _bpos,
-        'red': _red,
-        'orange': _orange,
-        'yellow': _yellow,
-        'green': _green,
-        'cyan': _cyan,
-        'blue': _blue,
-        'purple': _purple,
-        'white': _white,
-        'black': _black,
-        'titlex': _titlex,
-        'titley': _titley,
-        'leftx': _leftx,
-        'topy': _topy,
-        'rightx': _rightx,
-        'bottomy': _bottomy,
-        'width': _width,
-        'height': _height}
+        "lpos": _lpos,
+        "tpos": _tpos,
+        "rpos": _rpos,
+        "bpos": _bpos,
+        "red": _red,
+        "orange": _orange,
+        "yellow": _yellow,
+        "green": _green,
+        "cyan": _cyan,
+        "blue": _blue,
+        "purple": _purple,
+        "white": _white,
+        "black": _black,
+        "titlex": _titlex,
+        "titley": _titley,
+        "leftx": _leftx,
+        "topy": _topy,
+        "rightx": _rightx,
+        "bottomy": _bottomy,
+        "width": _width,
+        "height": _height,
+    }
 
     stacks_of_blocks = tw.just_blocks()
     stack_count = 0
 
-    logocode = ''
+    logocode = ""
 
     """
     Walk through the code, substituting UCB Logo for Turtle Art primitives.
     """
     for stack in stacks_of_blocks:
-        this_stack = ''
+        this_stack = ""
         psuedocode = _walk_stack(tw, stack)
         if psuedocode == []:
             continue
@@ -87,88 +89,98 @@ def save_logo(tw):
                 logo_command = logo_commands[blk]
             else:
                 logo_command = None
-            if i == 0 and logo_command not in ['to stack1\n', 'to stack2\n',
-                                               'to action', 'to start\n']:
-                this_stack = 'to turtleblocks_%d\n' % (stack_count)
+            if i == 0 and logo_command not in [
+                "to stack1\n",
+                "to stack2\n",
+                "to action",
+                "to start\n",
+            ]:
+                this_stack = "to turtleblocks_%d\n" % (stack_count)
                 stack_count += 1
             if logo_command in dispatch_table:
                 if i + 1 < len(psuedocode):
-                    this_stack += dispatch_table[logo_command](
-                        psuedocode[i + 1])
+                    this_stack += dispatch_table[logo_command](psuedocode[i + 1])
                     skip = True
                 else:
-                    print('missing arg to %s' % (logo_command))
+                    print("missing arg to %s" % (logo_command))
             elif logo_command in constants_table:
                 this_stack += str(constants_table[logo_command](tw))
             elif logo_command is not None:
                 this_stack += logo_command
             else:  # assume it is an argument
-                if blk not in ['nop', 'nop1', 'nop2', 'nop3']:
-                    if isinstance(blk, str) and blk[0:2] == '#s':
-                        this_stack += str(blk[2:]).replace(' ', '_')
+                if blk not in ["nop", "nop1", "nop2", "nop3"]:
+                    if isinstance(blk, str) and blk[0:2] == "#s":
+                        this_stack += str(blk[2:]).replace(" ", "_")
                     else:
-                        this_stack += str(blk).replace(' ', '_')
-            this_stack += ' '
+                        this_stack += str(blk).replace(" ", "_")
+            this_stack += " "
 
         logocode += this_stack
-        logocode += '\nend\n'
+        logocode += "\nend\n"
 
     # We may need to prepend some additional procedures.
     for key in list(logo_functions.keys()):
         if key in logocode:
             logocode = logo_functions[key] + logocode
 
-    if 'tasetshade' in logocode or 'tasetpencolor' in logocode or \
-       'tasetbackground' in logocode:
-        logocode = logo_functions['tacolor'] + logocode
+    if (
+        "tasetshade" in logocode
+        or "tasetpencolor" in logocode
+        or "tasetbackground" in logocode
+    ):
+        logocode = logo_functions["tacolor"] + logocode
 
-    logocode = 'window\n' + logocode
+    logocode = "window\n" + logocode
     return logocode
 
 
 def _add_label(string):
-    if datastore is not None and isinstance(string, str) and string[0:8] in ['#smedia_', '#saudio_', '#svideo_', '#sdescr_']:
+    if (
+        datastore is not None
+        and isinstance(string, str)
+        and string[0:8] in ["#smedia_", "#saudio_", "#svideo_", "#sdescr_"]
+    ):
         string = string[8:]
         dsobject = datastore.get(string[8:])
-        if 'title' in dsobject.metadata:
-            string = dsobject.metadata['title']
+        if "title" in dsobject.metadata:
+            string = dsobject.metadata["title"]
     else:
         string = str(string)
-    if string[0:2] == '#s':
+    if string[0:2] == "#s":
         string = string[2:]
         string = '"' + string
-    if string.count(' ') > 0:
-        return 'label sentence %s\n' % (string.replace(' ', ' "'))
+    if string.count(" ") > 0:
+        return "label sentence %s\n" % (string.replace(" ", ' "'))
     else:
-        return 'label %s' % (string.replace(' ', '_'))
+        return "label %s" % (string.replace(" ", "_"))
 
 
 def _add_named_stack(action):
-    if isinstance(action, str) and action[0:2] == '#s':
-        return 'to %s\n' % (str(action[2:]).replace(' ', '_'))
+    if isinstance(action, str) and action[0:2] == "#s":
+        return "to %s\n" % (str(action[2:]).replace(" ", "_"))
     else:
-        return 'to %s\n' % (str(action).replace(' ', '_'))
+        return "to %s\n" % (str(action).replace(" ", "_"))
 
 
 def _add_reference_to_stack(action):
-    if isinstance(action, str) and action[0:2] == '#s':
-        return '%s' % (str(action[2:]).replace(' ', '_'))
+    if isinstance(action, str) and action[0:2] == "#s":
+        return "%s" % (str(action[2:]).replace(" ", "_"))
     else:
-        return '%s' % (str(action).replace(' ', '_'))
+        return "%s" % (str(action).replace(" ", "_"))
 
 
 def _add_named_box(box_name):
-    if isinstance(box_name, str) and box_name[0:2] == '#s':
-        return 'make "%s' % (str(box_name[2:]).replace(' ', '_'))
+    if isinstance(box_name, str) and box_name[0:2] == "#s":
+        return 'make "%s' % (str(box_name[2:]).replace(" ", "_"))
     else:
-        return 'make "%s' % (str(box_name).replace(' ', '_'))
+        return 'make "%s' % (str(box_name).replace(" ", "_"))
 
 
 def _add_reference_to_box(box_name):
-    if isinstance(box_name, str) and box_name[0:2] == '#s':
-        return ':%s' % (str(box_name[2:]).replace(' ', '_'))
+    if isinstance(box_name, str) and box_name[0:2] == "#s":
+        return ":%s" % (str(box_name[2:]).replace(" ", "_"))
     else:
-        return ':%s' % (str(box_name).replace(' ', '_'))
+        return ":%s" % (str(box_name).replace(" ", "_"))
 
 
 def _lpos(tw):
@@ -208,8 +220,7 @@ def _leftx(tw):
 
 
 def _topy(tw):
-    return int((tw.canvas.height * (
-        TITLEXY[1] - 0.125)) / (tw.coord_scale * 2))
+    return int((tw.canvas.height * (TITLEXY[1] - 0.125)) / (tw.coord_scale * 2))
 
 
 def _rightx(tw):
@@ -221,31 +232,31 @@ def _bottomy(tw):
 
 
 def _red(tw):
-    return CONSTANTS['red']
+    return CONSTANTS["red"]
 
 
 def _orange(tw):
-    return CONSTANTS['orange']
+    return CONSTANTS["orange"]
 
 
 def _yellow(tw):
-    return CONSTANTS['yellow']
+    return CONSTANTS["yellow"]
 
 
 def _green(tw):
-    return CONSTANTS['green']
+    return CONSTANTS["green"]
 
 
 def _cyan(tw):
-    return CONSTANTS['cyan']
+    return CONSTANTS["cyan"]
 
 
 def _blue(tw):
-    return CONSTANTS['blue']
+    return CONSTANTS["blue"]
 
 
 def _purple(tw):
-    return CONSTANTS['purple']
+    return CONSTANTS["purple"]
 
 
 def _white(tw):

--- a/TurtleArt/talogo.py
+++ b/TurtleArt/talogo.py
@@ -33,26 +33,41 @@ from time import time, sleep
 
 from gi.repository import GLib
 from gi.repository import GdkPixbuf
+
 try:
     from sugar3.graphics import style
+
     GRID_CELL_SIZE = style.GRID_CELL_SIZE
 except ImportError:
     GRID_CELL_SIZE = 55
 
-USER_HOME = os.path.expanduser('~')
+USER_HOME = os.path.expanduser("~")
 
 import traceback
 
-from .tablock import (Block, Media, media_blocks_dictionary)
-from .taconstants import (TAB_LAYER, DEFAULT_SCALE, ICON_SIZE)
-from .tajail import (myfunc, myfunc_import)
-from .tapalette import (block_names, value_blocks)
-from .tatype import (TATypeError, TYPES_NUMERIC)
-from .tautils import (get_pixbuf_from_journal, data_from_file, get_stack_name,
-                      movie_media_type, audio_media_type, image_media_type,
-                      text_media_type, round_int, debug_output, find_group,
-                      get_path, image_to_base64, data_to_string, data_to_file,
-                      get_load_name, chooser_dialog)
+from .tablock import Block, Media, media_blocks_dictionary
+from .taconstants import TAB_LAYER, DEFAULT_SCALE, ICON_SIZE
+from .tajail import myfunc, myfunc_import
+from .tapalette import block_names, value_blocks
+from .tatype import TATypeError, TYPES_NUMERIC
+from .tautils import (
+    get_pixbuf_from_journal,
+    data_from_file,
+    get_stack_name,
+    movie_media_type,
+    audio_media_type,
+    image_media_type,
+    text_media_type,
+    round_int,
+    debug_output,
+    find_group,
+    get_path,
+    image_to_base64,
+    data_to_string,
+    data_to_file,
+    get_load_name,
+    chooser_dialog,
+)
 
 try:
     from .util.RtfParser import RtfTextOnly
@@ -67,13 +82,11 @@ primitive_dictionary = {}  # new block primitives get added here
 
 
 class noKeyError(UserDict):
-
     def __missing__(x, y):
         return 0
 
 
 class symbol:
-
     def __init__(self, name):
         self.name = name
         self.nargs = None
@@ -83,11 +96,10 @@ class symbol:
         return self.name
 
     def __repr__(self):
-        return '#' + self.name
+        return "#" + self.name
 
 
 class logoerror(Exception):
-
     def __init__(self, value):
         self.value = value
 
@@ -97,10 +109,10 @@ class logoerror(Exception):
 
 
 class NegativeRootError(BaseException):
-    """ Similar to the ZeroDivisionError, this error is raised at runtime
-    when trying to computer the square root of a negative number. """
+    """Similar to the ZeroDivisionError, this error is raised at runtime
+    when trying to computer the square root of a negative number."""
 
-    DEFAULT_MESSAGE = 'square root of negative number'
+    DEFAULT_MESSAGE = "square root of negative number"
 
     def __init__(self, neg_value=None, message=DEFAULT_MESSAGE):
         self.neg_value = neg_value
@@ -111,7 +123,6 @@ class NegativeRootError(BaseException):
 
 
 class HiddenBlock(Block):
-
     def __init__(self, name, value=None):
         self.name = name
         self.values = []
@@ -128,18 +139,18 @@ class HiddenBlock(Block):
 
 
 def _change_user_path(path):
-    ''' If the pathname saved in a project was from a different user, try
-    changing it.'''
+    """If the pathname saved in a project was from a different user, try
+    changing it."""
     # FIXME: Use regex
     if path is None:
         return None
     if len(path) < 7:
         return None
-    if '/' not in path[6:]:
+    if "/" not in path[6:]:
         return None
-    if path[0:5] == '/home' and '/':
-        i = path[6:].index('/')
-        new_path = USER_HOME + path[6 + i:]
+    if path[0:5] == "/home" and "/":
+        i = path[6:].index("/")
+        new_path = USER_HOME + path[6 + i :]
         if new_path == path:
             return None
         else:
@@ -164,9 +175,11 @@ class LogoCode:
         self.tw = tw
         self.oblist = {}
 
-        DEFPRIM = {'(': [1, lambda self, x: self._prim_opar(x)],
-                   'define': [2, self._prim_define],
-                   'nop': [0, lambda self: None]}
+        DEFPRIM = {
+            "(": [1, lambda self, x: self._prim_opar(x)],
+            "define": [2, self._prim_define],
+            "nop": [0, lambda self: None],
+        }
 
         for p in iter(DEFPRIM):
             if len(DEFPRIM[p]) == 2:
@@ -174,9 +187,9 @@ class LogoCode:
             else:
                 self.def_prim(p, DEFPRIM[p][0], DEFPRIM[p][1], DEFPRIM[p][2])
 
-        self.symtype = type(self._intern('print'))
-        self.symnothing = self._intern('%nothing%')
-        self.symopar = self._intern('(')
+        self.symtype = type(self._intern("print"))
+        self.symnothing = self._intern("%nothing%")
+        self.symopar = self._intern("(")
         self.iline = None
         self.cfun = None
         self.arglist = None
@@ -185,7 +198,7 @@ class LogoCode:
         self.running = False
         self.istack = []
         self.stacks = {}
-        self.boxes = {'box1': 0, 'box2': 0}
+        self.boxes = {"box1": 0, "box2": 0}
         self.return_values = []
         self.heap = []
         self.iresults = None
@@ -216,6 +229,7 @@ class LogoCode:
         self.tw.stop_plugins()
         if self.tw.gst_available:
             from .tagplay import stop_media
+
             stop_media(self)
         self.tw.turtles.get_active_turtle().show()
         self.tw.running_blocks = False
@@ -247,26 +261,23 @@ class LogoCode:
             return None
 
     def run_blocks(self, code):
-        """Run code generated by generate_code().
-        """
+        """Run code generated by generate_code()."""
         self.start_time = time()
         self._setup_cmd(code)
 
     def generate_code(self, blk, blocks):
-        """ Generate code to be passed to run_blocks() from a stack of blocks.
-        """
+        """Generate code to be passed to run_blocks() from a stack of blocks."""
         self._save_all_connections = []
         for b in blocks:
             tmp = []
             for c in b.connections:
                 tmp.append(c)
-            self._save_all_connections.append(
-                {'blk': b, 'connections': tmp})
+            self._save_all_connections.append({"blk": b, "connections": tmp})
 
         for k in list(self.stacks.keys()):
             self.stacks[k] = None
-        self.stacks['stack1'] = None
-        self.stacks['stack2'] = None
+        self.stacks["stack1"] = None
+        self.stacks["stack2"] = None
 
         # Save state in case there is a hidden macro expansion
         self._save_blocks = None
@@ -289,34 +300,34 @@ class LogoCode:
 
         # Hidden macro expansions
         for b in blocks:
-            if b.name in ['returnstack']:
+            if b.name in ["returnstack"]:
                 action_blk, new_blocks = self._expand_return(b, blk, blocks)
                 blocks = new_blocks[:]
                 if b == blk:
                     blk = action_blk
 
         for b in blocks:
-            if b.name in ['while', 'until']:
+            if b.name in ["while", "until"]:
                 action_blk, new_blocks = self._expand_forever(b, blk, blocks)
                 blocks = new_blocks[:]
                 if b == blk:
                     blk = action_blk
         for b in blocks:
-            if b.name in ['forever']:
+            if b.name in ["forever"]:
                 action_blk, new_blocks = self._expand_forever(b, blk, blocks)
                 blocks = new_blocks[:]
                 if b == blk:
                     blk = action_blk
 
         for b in blocks:
-            if b.name in ('hat', 'hat1', 'hat2'):
+            if b.name in ("hat", "hat1", "hat2"):
                 stack_name = get_stack_name(b)
                 if stack_name:
                     stack_key = self._get_stack_key(stack_name)
                     code = self._blocks_to_code(b)
                     self.stacks[stack_key] = self._readline(code)
                 else:
-                    self.tw.showlabel('#nostack')
+                    self.tw.showlabel("#nostack")
                     self.tw.showblocks()
                     self.tw.running_blocks = False
                     return None
@@ -339,8 +350,8 @@ class LogoCode:
             # Restore any connections that may have been mangled
             # during macro expansion.
             for entry in self._save_all_connections:
-                b = entry['blk']
-                connections = entry['connections']
+                b = entry["blk"]
+                connections = entry["connections"]
                 b.connections = connections[:]
 
         return code
@@ -348,38 +359,37 @@ class LogoCode:
     def _blocks_to_code(self, blk):
         """ Convert a stack of blocks to pseudocode. """
         if blk is None:
-            return ['%nothing%', '%nothing%']
+            return ["%nothing%", "%nothing%"]
         code = []
         dock = blk.docks[0]
         # There could be a '(', ')', '[' or ']'.
-        if len(dock) > 4 and dock[4] in ('[', ']', ']['):
+        if len(dock) > 4 and dock[4] in ("[", "]", "]["):
             code.append(dock[4])
         if blk.primitive is not None:  # make a tuple (prim, blk)
             if blk in self.tw.block_list.list:
-                code.append((blk.primitive,
-                             self.tw.block_list.list.index(blk)))
+                code.append((blk.primitive, self.tw.block_list.list.index(blk)))
             else:
                 code.append(blk.primitive)  # Hidden block
         elif blk.is_value_block():  # Extract the value from content blocks.
             value = blk.get_value()
             if value is None:
-                return ['%nothing%']
+                return ["%nothing%"]
             else:
                 code.append(value)
         else:
-            return ['%nothing%']
+            return ["%nothing%"]
         if blk.connections is not None and len(blk.connections) > 0:
             for i in range(1, len(blk.connections)):
                 b = blk.connections[i]
                 dock = blk.docks[i]
                 # There could be a '(', ')', '[' or ']'.
-                if len(dock) > 4 and dock[4] in ('[', ']', ']['):
+                if len(dock) > 4 and dock[4] in ("[", "]", "]["):
                     for c in dock[4]:
                         code.append(c)
                 if b is not None:
                     code.extend(self._blocks_to_code(b))
-                elif blk.docks[i][0] not in ['flow', 'unavailable']:
-                    code.append('%nothing%')
+                elif blk.docks[i][0] not in ["flow", "unavailable"]:
+                    code.append("%nothing%")
         return code
 
     def _setup_cmd(self, string):
@@ -409,15 +419,15 @@ class LogoCode:
                 res.append(token)
             elif token.isdigit():
                 res.append(float(token))
-            elif token[0] == '-' and token[1:].isdigit():
+            elif token[0] == "-" and token[1:].isdigit():
                 res.append(-float(token[1:]))
             elif token[0] == '"':
                 res.append(token[1:])
             elif token[0:2] == "#s":
                 res.append(token[2:])
-            elif token == '[':
+            elif token == "[":
                 res.append(self._readline(line))
-            elif token == ']':
+            elif token == "]":
                 return res
             elif bindex is None or not isinstance(bindex, int):
                 res.append(self._intern(token))
@@ -429,25 +439,21 @@ class LogoCode:
         """ Step through the list. """
         if self.tw.running_sugar:
             self.tw.activity.stop_turtle_button.set_icon_name("stopiton")
-            self.tw.activity.stop_turtle_button.set_tooltip(
-                _('Stop turtle'))
+            self.tw.activity.stop_turtle_button.set_tooltip(_("Stop turtle"))
         elif self.tw.interactive_mode:
-            self.tw.toolbar_shapes['stopiton'].set_layer(TAB_LAYER)
+            self.tw.toolbar_shapes["stopiton"].set_layer(TAB_LAYER)
         self.running = True
         self.icall(self.evline, blklist)
         yield True
         if self.tw.running_sugar:
             if self.tw.step_time == 0 and self.tw.selected_blk is None:
                 self.tw.activity.stop_turtle_button.set_icon_name("hideshowon")
-                self.tw.activity.stop_turtle_button.set_tooltip(
-                    _('Show blocks'))
+                self.tw.activity.stop_turtle_button.set_tooltip(_("Show blocks"))
             else:
-                self.tw.activity.stop_turtle_button.set_icon_name(
-                    "hideshowoff")
-                self.tw.activity.stop_turtle_button.set_tooltip(
-                    _('Hide blocks'))
+                self.tw.activity.stop_turtle_button.set_icon_name("hideshowoff")
+                self.tw.activity.stop_turtle_button.set_tooltip(_("Hide blocks"))
         elif self.tw.interactive_mode:
-            self.tw.toolbar_shapes['stopiton'].hide()
+            self.tw.toolbar_shapes["stopiton"].hide()
         yield False
         self.running = False
         # If we disabled hover help, reenable it
@@ -491,7 +497,7 @@ class LogoCode:
             # In debugging modes, we pause between steps and show the turtle.
             if self.tw.step_time > 0:
                 self.tw.turtles.get_active_turtle().show()
-                endtime = _millisecond() + self.tw.step_time * 100.
+                endtime = _millisecond() + self.tw.step_time * 100.0
                 while _millisecond() < endtime:
                     sleep(0.1)
                     yield True
@@ -567,9 +573,8 @@ class LogoCode:
             self.tw.showblocks()
             self.tw.display_coordinates()
             raise logoerror("#noinput")
-        is_Primitive = type(self.cfun.fcn).__name__ == 'Primitive'
-        is_PrimitiveDisjunction = type(self.cfun.fcn).__name__ == \
-            'PrimitiveDisjunction'
+        is_Primitive = type(self.cfun.fcn).__name__ == "Primitive"
+        is_PrimitiveDisjunction = type(self.cfun.fcn).__name__ == "PrimitiveDisjunction"
         call_args = not (is_Primitive or is_PrimitiveDisjunction)
         for i in range(token.nargs):
             self._no_args_check()
@@ -602,9 +607,9 @@ class LogoCode:
         self.cfun, self.arglist = oldcfun, oldarglist
         if self.arglist is not None and result is None:
             self.tw.showblocks()
-            raise logoerror("%s %s %s" %
-                            (oldcfun.name, _("did not output to"),
-                             self.cfun.name))
+            raise logoerror(
+                "%s %s %s" % (oldcfun.name, _("did not output to"), self.cfun.name)
+            )
         if need_to_pop_istack:
             self.ireturn(result)
             yield True
@@ -629,8 +634,9 @@ class LogoCode:
                         try:
                             next(self.step)
                         except ValueError:
-                            debug_output('generator already executing',
-                                         self.tw.running_sugar)
+                            debug_output(
+                                "generator already executing", self.tw.running_sugar
+                            )
                             self.tw.running_blocks = False
                             return False
                         except TATypeError as tte:
@@ -638,14 +644,21 @@ class LogoCode:
                             # (self.cfun.name is only the name of the
                             # outermost block in this statement/ line of code)
                             # use logoerror("#notanumber") when possible
-                            if tte.req_type in TYPES_NUMERIC and \
-                                    tte.bad_type not in TYPES_NUMERIC:
+                            if (
+                                tte.req_type in TYPES_NUMERIC
+                                and tte.bad_type not in TYPES_NUMERIC
+                            ):
                                 raise logoerror("#notanumber")
                             else:
                                 raise logoerror(
-                                    "%s %s %s %s" %
-                                    (self.cfun.name, _("doesn't like"),
-                                     str(tte.bad_value), _("as input")))
+                                    "%s %s %s %s"
+                                    % (
+                                        self.cfun.name,
+                                        _("doesn't like"),
+                                        str(tte.bad_value),
+                                        _("as input"),
+                                    )
+                                )
                         except ZeroDivisionError:
                             raise logoerror("#zerodivide")
                         except NegativeRootError:
@@ -656,15 +669,15 @@ class LogoCode:
                         try:
                             next(self.step)
                         except BaseException as error:
-                            if isinstance(error, (StopIteration,
-                                                  logoerror)):
+                            if isinstance(error, (StopIteration, logoerror)):
                                 self.tw.running_blocks = False
                                 raise error
                             else:
                                 traceback.print_exc()
                                 self.tw.showlabel(
-                                    'status', '%s: %s' %
-                                    (type(error).__name__, str(error)))
+                                    "status",
+                                    "%s: %s" % (type(error).__name__, str(error)),
+                                )
                                 self.tw.running_blocks = False
                                 return False
                 except StopIteration:
@@ -683,11 +696,11 @@ class LogoCode:
             if self.tw.running_turtleart:
                 self.tw.showblocks()
                 self.tw.display_coordinates()
-                self.tw.showlabel('syntaxerror', str(e))
+                self.tw.showlabel("syntaxerror", str(e))
                 self.tw.turtles.show_all()
             else:
                 traceback.print_exc()
-                self.tw.showlabel('status', 'logoerror: ' + str(e))
+                self.tw.showlabel("status", "logoerror: " + str(e))
             self.tw.running_blocks = False
             return False
         return True
@@ -705,8 +718,8 @@ class LogoCode:
         """ Make sure token has a definition """
         if token.fcn is not None:
             return False
-        if token.name == '%nothing%':
-            errormsg = ''
+        if token.name == "%nothing%":
+            errormsg = ""
         else:
             errormsg = "%s %s" % (_("I don't know how to"), _(token.name))
         self.tw.showblocks()
@@ -736,7 +749,7 @@ class LogoCode:
         name.rprim = True
 
     def prim_start(self, *ignored_args):
-        ''' Start block: recenter '''
+        """ Start block: recenter """
         if self.tw.running_sugar:
             self.tw.activity.recenter()
 
@@ -754,6 +767,7 @@ class LogoCode:
     def stop_playing_media(self):
         if self.tw.gst_available:
             from .tagplay import stop_media
+
             stop_media(self)
 
     def reset_scale(self):
@@ -771,16 +785,18 @@ class LogoCode:
             self.tw.activity.restore_state()
 
     def prim_loop(self, controller, blklist):
-        """ Execute a loop
+        """Execute a loop
         controller -- iterator that yields True iff the loop should be run
             once more OR a callable that returns such an iterator
-        blklist -- list of callables that form the loop body """
+        blklist -- list of callables that form the loop body"""
         if not hasattr(controller, "__next__"):
             if callable(controller):
                 controller = controller()
             else:
-                raise TypeError("a loop controller must be either an iterator "
-                                "or a callable that returns an iterator")
+                raise TypeError(
+                    "a loop controller must be either an iterator "
+                    "or a callable that returns an iterator"
+                )
         while next(controller):
             self.icall(self.evline, blklist[:])
             yield True
@@ -798,11 +814,11 @@ class LogoCode:
         yield True
 
     def set_scale(self, scale):
-        ''' Set scale for media blocks '''
+        """ Set scale for media blocks """
         self.scale = scale
 
     def get_scale(self):
-        ''' Set scale for media blocks '''
+        """ Set scale for media blocks """
         return self.scale
 
     def prim_stop_stack(self):
@@ -816,7 +832,7 @@ class LogoCode:
         self.procstop = True
 
     def active_turtle(self):
-        ''' NOP used to add get_active_turtle to Python export '''
+        """ NOP used to add get_active_turtle to Python export """
         # turtle = self.tw.turtles.get_turtle()
         pass
 
@@ -826,9 +842,9 @@ class LogoCode:
     def prim_wait(self, wait_time):
         """ Show the turtle while we wait """
         self.tw.turtles.get_active_turtle().show()
-        endtime = _millisecond() + wait_time * 1000.
+        endtime = _millisecond() + wait_time * 1000.0
         while _millisecond() < endtime:
-            sleep(wait_time / 10.)
+            sleep(wait_time / 10.0)
             yield True
         self.tw.turtles.get_active_turtle().hide()
         self.ireturn()
@@ -860,11 +876,11 @@ class LogoCode:
                 self.update_label_value(name, value)
         else:
             if self.update_values:
-                self.update_label_value('box', value, label=name)
+                self.update_label_value("box", value, label=name)
 
     def prim_get_box(self, name):
         """ Retrieve value from named box """
-        if name == '__return__':
+        if name == "__return__":
             if len(self.return_values) == 0:
                 raise logoerror("#emptybox")
             return self.return_values.pop()
@@ -877,9 +893,9 @@ class LogoCode:
             raise logoerror("#emptybox")
 
     def _get_box_key(self, name):
-        """ Return the key used for this box in the boxes dictionary and a
-        boolean indicating whether it is a 'native' box """
-        if name in ('box1', 'box2'):
+        """Return the key used for this box in the boxes dictionary and a
+        boolean indicating whether it is a 'native' box"""
+        if name in ("box1", "box2"):
             return (name, True)
         # elif name == '__return__':
         #     return (name, True)
@@ -890,7 +906,7 @@ class LogoCode:
                     name = float(name)
                 except ValueError:
                     pass
-            return ('box3_' + str(name), False)
+            return ("box3_" + str(name), False)
 
     def prim_define_stack(self, name):
         """ Top of a named stack """
@@ -910,11 +926,11 @@ class LogoCode:
     def prim_invoke_return_stack(self, name):
         """ Process a named stack and return a value"""
         self.prim_invoke_stack(name)
-        return self.boxes['__return__']
+        return self.boxes["__return__"]
 
     def _get_stack_key(self, name):
         """ Return the key used for this stack in the stacks dictionary """
-        if name in ('stack1', 'stack2'):
+        if name in ("stack1", "stack2"):
             return name
         else:
             # make sure '5' and '5.0' point to the same action stack
@@ -923,7 +939,7 @@ class LogoCode:
                     name = int(name)
                 else:
                     name = float(name)
-            return 'stack3' + str(name)
+            return "stack3" + str(name)
 
     def load_heap(self, obj):
         """ Load FILO from file """
@@ -934,11 +950,13 @@ class LogoCode:
             # Is the object a dsobject?
             if isinstance(obj, Media) and obj.value:
                 from sugar3.datastore import datastore
+
                 try:
                     dsobject = datastore.get(obj.value)
                 except BaseException:
-                    debug_output("Couldn't find dsobject %s" %
-                                 (obj.value), self.tw.running_sugar)
+                    debug_output(
+                        "Couldn't find dsobject %s" % (obj.value), self.tw.running_sugar
+                    )
                 if dsobject is not None:
                     self.push_file_data_to_heap(dsobject)
             # Or is it a path?
@@ -946,13 +964,11 @@ class LogoCode:
                 self.push_file_data_to_heap(None, path=obj)
             elif user_path is not None and os.path.exists(user_path):
                 self.push_file_data_to_heap(None, path=user_path)
-            elif os.path.exists(os.path.join(
-                    self.tw.activity.get_bundle_path(), obj)):
+            elif os.path.exists(os.path.join(self.tw.activity.get_bundle_path(), obj)):
                 self.push_file_data_to_heap(None, path=obj)
             else:
                 # Finally try choosing a datastore object
-                chooser_dialog(self.tw.parent, obj,
-                               self.push_file_data_to_heap)
+                chooser_dialog(self.tw.parent, obj, self.push_file_data_to_heap)
         else:
             # If you cannot find the file, open a chooser.
             if os.path.exists(obj):
@@ -961,7 +977,8 @@ class LogoCode:
                 self.push_file_data_to_heap(None, path=user_path)
             else:
                 obj, self.tw.load_save_folder = get_load_name(
-                    '.*', self.tw.load_save_folder)
+                    ".*", self.tw.load_save_folder
+                )
                 if obj is not None:
                     self.push_file_data_to_heap(None, path=obj)
 
@@ -973,8 +990,7 @@ class LogoCode:
             from sugar3.activity import activity
 
             # Save JSON-encoded heap to temporary file
-            heap_file = os.path.join(get_path(activity, 'instance'),
-                                     'heap.txt')
+            heap_file = os.path.join(get_path(activity, "instance"), "heap.txt")
             data_to_file(self.heap, heap_file)
 
             # Write to an existing or new dsobject
@@ -982,10 +998,9 @@ class LogoCode:
                 dsobject = datastore.get(obj.value)
             else:
                 dsobject = datastore.create()
-                dsobject.metadata['title'] = str(obj)
-                dsobject.metadata['icon-color'] = \
-                    profile.get_color().to_string()
-                dsobject.metadata['mime_type'] = 'text/plain'
+                dsobject.metadata["title"] = str(obj)
+                dsobject.metadata["icon-color"] = profile.get_color().to_string()
+                dsobject.metadata["mime_type"] = "text/plain"
             dsobject.set_file_path(heap_file)
             datastore.write(dsobject)
             dsobject.destroy()
@@ -1018,13 +1033,12 @@ class LogoCode:
                 raise logoerror("#syntaxerror")
 
     def prim_myfunction(self, f, *args):
-        """ Programmable block (Call tajail.myfunc and convert any errors to
-        logoerrors) """
+        """Programmable block (Call tajail.myfunc and convert any errors to
+        logoerrors)"""
         try:
             y = myfunc(f, args)
-            if str(y) == 'nan':
-                debug_output('Python function returned NAN',
-                             self.tw.running_sugar)
+            if str(y) == "nan":
+                debug_output("Python function returned NAN", self.tw.running_sugar)
                 self.stop_logo()
                 raise logoerror("#notanumber")
             else:
@@ -1034,13 +1048,13 @@ class LogoCode:
             raise logoerror("#zerodivide")
         except ValueError as e:
             self.stop_logo()
-            raise logoerror('#' + str(e))
+            raise logoerror("#" + str(e))
         except SyntaxError as e:
             self.stop_logo()
-            raise logoerror('#' + str(e))
+            raise logoerror("#" + str(e))
         except NameError as e:
             self.stop_logo()
-            raise logoerror('#' + str(e))
+            raise logoerror("#" + str(e))
         except OverflowError:
             self.stop_logo()
             raise logoerror("#overflowerror")
@@ -1049,7 +1063,7 @@ class LogoCode:
             raise logoerror("#notanumber")
 
     def clear_value_blocks(self):
-        if not hasattr(self, 'value_blocks_to_update'):
+        if not hasattr(self, "value_blocks_to_update"):
             return
         for name in value_blocks:
             self.update_label_value(name)
@@ -1058,8 +1072,9 @@ class LogoCode:
         """ Find any value blocks that may need label updates """
         self.value_blocks_to_update = {}
         for name in value_blocks:
-            self.value_blocks_to_update[name] = \
-                self.tw.block_list.get_similar_blocks('block', name)
+            self.value_blocks_to_update[name] = self.tw.block_list.get_similar_blocks(
+                "block", name
+            )
 
     def update_label_value(self, name, value=None, label=None):
         """ Update the label of value blocks to reflect current value """
@@ -1074,7 +1089,7 @@ class LogoCode:
                 return
             for block in self.value_blocks_to_update[name]:
                 block.spr.set_label(block_names[name][0])
-                if name == 'box':
+                if name == "box":
                     argblk = block.connections[-2]
                     dx = block.dx
                     block.resize()
@@ -1088,23 +1103,20 @@ class LogoCode:
                     block.resize()
         elif self.update_values:
             if isinstance(value, float):
-                valstring = str(round_int(value)).replace(
-                    '.', self.tw.decimal_point)
+                valstring = str(round_int(value)).replace(".", self.tw.decimal_point)
             else:
                 valstring = str(value)
             if name not in self.value_blocks_to_update:
                 return
             for block in self.value_blocks_to_update[name]:
                 if label is None:
-                    block.spr.set_label(
-                        block_names[name][0] + ' = ' + valstring)
+                    block.spr.set_label(block_names[name][0] + " = " + valstring)
                     block.resize()
                 else:
                     argblk = block.connections[-2]
                     # Only update if label matches
                     if argblk is not None and argblk.spr.labels[0] == label:
-                        block.spr.set_label(
-                            block_names[name][0] + ' = ' + valstring)
+                        block.spr.set_label(block_names[name][0] + " = " + valstring)
                         dx = block.dx
                         block.resize()
                         # Move connections over...
@@ -1128,26 +1140,28 @@ class LogoCode:
             self.filepath = user_path
         elif self.tw.running_sugar:  # datastore object
             from sugar3.datastore import datastore
+
             try:
                 self.dsobject = datastore.get(obj.value)
             except BaseException:
-                debug_output("Couldn't find dsobject %s" %
-                             (obj.value), self.tw.running_sugar)
+                debug_output(
+                    "Couldn't find dsobject %s" % (obj.value), self.tw.running_sugar
+                )
             if self.dsobject is not None:
                 self.filepath = self.dsobject.file_path
 
         if self.filepath is None:
-            self.tw.showlabel('nojournal', self.filepath)
+            self.tw.showlabel("nojournal", self.filepath)
             return
 
         pixbuf = None
         try:
-            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(
-                self.filepath, scale, scale)
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(self.filepath, scale, scale)
         except BaseException:
-            self.tw.showlabel('nojournal', self.filepath)
-            debug_output("Couldn't open skin %s" % (self.filepath),
-                         self.tw.running_sugar)
+            self.tw.showlabel("nojournal", self.filepath)
+            debug_output(
+                "Couldn't open skin %s" % (self.filepath), self.tw.running_sugar
+            )
         if pixbuf is not None:
             self.tw.turtles.get_active_turtle().set_shapes([pixbuf])
             pen_state = self.tw.turtles.get_active_turtle().get_pen_state()
@@ -1159,20 +1173,22 @@ class LogoCode:
 
         if self.tw.sharing():
             if self.tw.running_sugar:
-                tmp_path = get_path(self.tw.activity, 'instance')
+                tmp_path = get_path(self.tw.activity, "instance")
             else:
                 tmp_path = tempfile.gettempdir()
-            tmp_file = os.path.join(get_path(self.tw.activity, 'instance'),
-                                    'tmpfile.png')
-            pixbuf.save(tmp_file, 'png', {'quality': '100'})
+            tmp_file = os.path.join(
+                get_path(self.tw.activity, "instance"), "tmpfile.png"
+            )
+            pixbuf.save(tmp_file, "png", {"quality": "100"})
             data = image_to_base64(tmp_file, tmp_path)
             height = pixbuf.get_height()
             width = pixbuf.get_width()
             event = data_to_string(
-                [self.tw.nick, [round_int(width), round_int(height), data]])
+                [self.tw.nick, [round_int(width), round_int(height), data]]
+            )
 
             def send_event(p):
-                self.tw.send_event('R', event)
+                self.tw.send_event("R", event)
                 return False
 
             GLib.idle_add(send_event)
@@ -1186,21 +1202,18 @@ class LogoCode:
         try:
             req = urllib.request.urlopen(url)
         except urllib.error.HTTPError as e:
-            debug_output("Couldn't open %s: %s" % (url, e),
-                         self.tw.running_sugar)
-            raise logoerror(url + ' [%d]' % (e.code))
+            debug_output("Couldn't open %s: %s" % (url, e), self.tw.running_sugar)
+            raise logoerror(url + " [%d]" % (e.code))
         except urllib.error.URLError as e:
-            if hasattr(e, 'code'):
-                debug_output("Couldn't open %s: %s" % (url, e),
-                             self.tw.running_sugar)
-                raise logoerror(url + ' [%d]' % (e.code))
+            if hasattr(e, "code"):
+                debug_output("Couldn't open %s: %s" % (url, e), self.tw.running_sugar)
+                raise logoerror(url + " [%d]" % (e.code))
             else:  # elif hasattr(e, 'reason'):
-                debug_output("Couldn't reach server: %s" % (e),
-                             self.tw.running_sugar)
-                raise logoerror('#noconnection')
+                debug_output("Couldn't reach server: %s" % (e), self.tw.running_sugar)
+                raise logoerror("#noconnection")
 
-        mediatype = req.getheader('Content-Type')
-        if mediatype[0:5] in ['image', 'audio', 'video']:
+        mediatype = req.getheader("Content-Type")
+        if mediatype[0:5] in ["image", "audio", "video"]:
             tmp = tempfile.NamedTemporaryFile(delete=False)
             tmp.write(req.read())
             tmp.flush()
@@ -1211,10 +1224,8 @@ class LogoCode:
 
     def showlist(self, objects):
         """ Display list of media objects """
-        x = (self.tw.turtles.get_active_turtle().get_xy(
-        )[0] / self.tw.coord_scale)
-        y = (self.tw.turtles.get_active_turtle().get_xy(
-        )[1] / self.tw.coord_scale)
+        x = self.tw.turtles.get_active_turtle().get_xy()[0] / self.tw.coord_scale
+        y = self.tw.turtles.get_active_turtle().get_xy()[1] / self.tw.coord_scale
         for obj in objects:
             self.tw.turtles.get_active_turtle().set_xy(x, y, pendown=False)
             self.show(obj)
@@ -1232,83 +1243,82 @@ class LogoCode:
             user_path = _change_user_path(obj.value)
             if obj.value.lower() in media_blocks_dictionary:
                 media_blocks_dictionary[obj.value.lower()]()
-                mediatype = 'image'  # camera snapshot
+                mediatype = "image"  # camera snapshot
             elif os_path_exists(obj.value):
                 self.filepath = obj.value
                 mediatype = obj.type
                 # If for some reason the obj.type is not set, try guessing.
                 if mediatype is None and self.filepath is not None:
                     if movie_media_type(self.filepath):
-                        mediatype = 'video'
+                        mediatype = "video"
                     elif audio_media_type(self.filepath):
-                        mediatype = 'audio'
+                        mediatype = "audio"
                     elif image_media_type(self.filepath):
-                        mediatype = 'image'
+                        mediatype = "image"
                     elif text_media_type(self.filepath):
-                        mediatype = 'text'
+                        mediatype = "text"
             elif user_path is not None and os_path_exists(user_path):
                 self.filepath = user_path
                 mediatype = obj.type
                 # If for some reason the obj.type is not set, try guessing.
                 if mediatype is None and self.filepath is not None:
                     if movie_media_type(self.filepath):
-                        mediatype = 'video'
+                        mediatype = "video"
                     elif audio_media_type(self.filepath):
-                        mediatype = 'audio'
+                        mediatype = "audio"
                     elif image_media_type(self.filepath):
-                        mediatype = 'image'
+                        mediatype = "image"
                     elif text_media_type(self.filepath):
-                        mediatype = 'text'
+                        mediatype = "text"
             elif self.tw.running_sugar:
                 from sugar3.datastore import datastore
+
                 try:
                     self.dsobject = datastore.get(obj.value)
                 except BaseException:
-                    debug_output("Couldn't find dsobject %s" %
-                                 (obj.value), self.tw.running_sugar)
+                    debug_output(
+                        "Couldn't find dsobject %s" % (obj.value), self.tw.running_sugar
+                    )
 
                 if self.dsobject is not None:
                     self.filepath = self.dsobject.file_path
-                    if 'mime_type' in self.dsobject.metadata:
-                        mimetype = self.dsobject.metadata['mime_type']
-                        if mimetype[0:5] == 'video':
-                            mediatype = 'video'
-                        elif mimetype[0:5] == 'audio':
-                            mediatype = 'audio'
-                        elif mimetype[0:5] == 'image':
-                            mediatype = 'image'
+                    if "mime_type" in self.dsobject.metadata:
+                        mimetype = self.dsobject.metadata["mime_type"]
+                        if mimetype[0:5] == "video":
+                            mediatype = "video"
+                        elif mimetype[0:5] == "audio":
+                            mediatype = "audio"
+                        elif mimetype[0:5] == "image":
+                            mediatype = "image"
                         else:
-                            mediatype = 'text'
+                            mediatype = "text"
 
             if self.pixbuf is not None:
                 self.insert_image(center=center, pixbuf=True)
             elif self.filepath is None:
                 if self.dsobject is not None:
-                    self.tw.showlabel(
-                        'nojournal',
-                        self.dsobject.metadata['title'])
+                    self.tw.showlabel("nojournal", self.dsobject.metadata["title"])
                 else:
-                    self.tw.showlabel('nojournal', obj.value)
+                    self.tw.showlabel("nojournal", obj.value)
 
-                debug_output("Couldn't open %s" % (obj.value),
-                             self.tw.running_sugar)
-            elif obj.type == 'media' or mediatype == 'image':
+                debug_output("Couldn't open %s" % (obj.value), self.tw.running_sugar)
+            elif obj.type == "media" or mediatype == "image":
                 self.insert_image(center=center)
-            elif mediatype == 'audio':
+            elif mediatype == "audio":
                 self.play_sound()
-            elif mediatype == 'video':
+            elif mediatype == "video":
                 self.play_video()
-            elif obj.type == 'descr' or mediatype == 'text':
+            elif obj.type == "descr" or mediatype == "text":
                 mimetype = None
-                if self.dsobject is not None and \
-                        'mime_type' in self.dsobject.metadata:
-                    mimetype = self.dsobject.metadata['mime_type']
+                if self.dsobject is not None and "mime_type" in self.dsobject.metadata:
+                    mimetype = self.dsobject.metadata["mime_type"]
 
                 description = None
-                if self.dsobject is not None and \
-                        'description' in self.dsobject.metadata:
-                    description = self.dsobject.metadata[
-                        'description']
+                if (
+                    self.dsobject is not None
+                    and "description" in self.dsobject.metadata
+                ):
+                    description = self.dsobject.metadata["description"]
 
                 self.insert_desc(mimetype, description)
 
@@ -1324,9 +1334,12 @@ class LogoCode:
                 y -= self.tw.canvas.textsize
 
             self.tw.turtles.get_active_turtle().draw_text(
-                obj, x, y,
-                int(self.tw.canvas.textsize * self.scale / 100.),
-                self.tw.canvas.width - x)
+                obj,
+                x,
+                y,
+                int(self.tw.canvas.textsize * self.scale / 100.0),
+                self.tw.canvas.width - x,
+            )
 
     def push_file_data_to_heap(self, dsobject, path=None):
         """ push contents of a data store object (assuming json encoding) """
@@ -1340,28 +1353,31 @@ class LogoCode:
         if data is not None:
             for val in data:
                 self.heap.append(val)
-            self.update_label_value('pop', self.heap[-1])
+            self.update_label_value("pop", self.heap[-1])
 
     def x2tx(self):
         """ Convert screen coordinates to turtle coordinates """
-        return int(self.tw.canvas.width / 2) + \
-            int(self.tw.turtles.get_active_turtle().get_xy()[0])
+        return int(self.tw.canvas.width / 2) + int(
+            self.tw.turtles.get_active_turtle().get_xy()[0]
+        )
 
     def y2ty(self):
         """ Convert screen coordinates to turtle coordinates """
-        return int(self.tw.canvas.height / 2) - \
-            int(self.tw.turtles.get_active_turtle().get_xy()[1])
+        return int(self.tw.canvas.height / 2) - int(
+            self.tw.turtles.get_active_turtle().get_xy()[1]
+        )
 
     def wpercent(self):
         """ width as a percentage of screen coordinates """
-        return int((self.tw.canvas.width * self.scale) / 100.)
+        return int((self.tw.canvas.width * self.scale) / 100.0)
 
     def hpercent(self):
         """ height as a percentage of screen coordinates """
-        return int((self.tw.canvas.height * self.scale) / 100.)
+        return int((self.tw.canvas.height * self.scale) / 100.0)
 
-    def insert_image(self, center=False, filepath=None, resize=True,
-                     offset=False, pixbuf=False):
+    def insert_image(
+        self, center=False, filepath=None, resize=True, offset=False, pixbuf=False
+    ):
         """ Image only (at current x, y) """
         if filepath is not None:
             self.filepath = filepath
@@ -1373,16 +1389,16 @@ class LogoCode:
         if pixbuf:  # We may have to rescale the picture
             if w != self.pixbuf.get_width() or h != self.pixbuf.get_height():
                 self.pixbuf = self.pixbuf.scale_simple(
-                    w, h, GdkPixbuf.InterpType.BILINEAR)
+                    w, h, GdkPixbuf.InterpType.BILINEAR
+                )
         elif self.dsobject is not None:
             try:
                 self.pixbuf = get_pixbuf_from_journal(self.dsobject, w, h)
             except BaseException:
-                debug_output("Couldn't open dsobject %s" % (self.dsobject),
-                             self.tw.running_sugar)
-        if self.pixbuf is None and \
-                self.filepath is not None and \
-                self.filepath != '':
+                debug_output(
+                    "Couldn't open dsobject %s" % (self.dsobject), self.tw.running_sugar
+                )
+        if self.pixbuf is None and self.filepath is not None and self.filepath != "":
             try:
                 if not resize:
                     self.pixbuf = GdkPixbuf.Pixbuf.new_from_file(self.filepath)
@@ -1390,33 +1406,36 @@ class LogoCode:
                     h = self.pixbuf.get_height()
                 else:
                     self.pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(
-                        self.filepath, w, h)
+                        self.filepath, w, h
+                    )
             except BaseException:
-                self.tw.showlabel('nojournal', self.filepath)
-                debug_output("Couldn't open filepath %s" % (self.filepath),
-                             self.tw.running_sugar)
+                self.tw.showlabel("nojournal", self.filepath)
+                debug_output(
+                    "Couldn't open filepath %s" % (self.filepath), self.tw.running_sugar
+                )
         if self.pixbuf is not None:
             # w, h are relative to screen size, not coord_scale
             # w *= self.tw.coord_scale
             # h *= self.tw.coord_scale
             if center:
                 self.tw.turtles.get_active_turtle().draw_pixbuf(
-                    self.pixbuf, 0, 0,
+                    self.pixbuf,
+                    0,
+                    0,
                     self.x2tx() - int(w / 2),
-                    self.y2ty() - int(h / 2), w, h,
-                    self.filepath)
+                    self.y2ty() - int(h / 2),
+                    w,
+                    h,
+                    self.filepath,
+                )
             elif offset:
                 self.tw.turtles.get_active_turtle().draw_pixbuf(
-                    self.pixbuf, 0, 0,
-                    self.x2tx(),
-                    self.y2ty() - h,
-                    w, h, self.filepath)
+                    self.pixbuf, 0, 0, self.x2tx(), self.y2ty() - h, w, h, self.filepath
+                )
             else:
                 self.tw.turtles.get_active_turtle().draw_pixbuf(
-                    self.pixbuf, 0, 0,
-                    self.x2tx(),
-                    self.y2ty(),
-                    w, h, self.filepath)
+                    self.pixbuf, 0, 0, self.x2tx(), self.y2ty(), w, h, self.filepath
+                )
 
     def insert_desc(self, mimetype=None, description=None):
         """ Description text only (at current x, y) """
@@ -1425,22 +1444,23 @@ class LogoCode:
             return
         text = None
         if text_media_type(self.filepath):
-            if RTFPARSE and \
-                    (mimetype == 'application/rtf' or self.filepath.endswith(
-                        'rtf')):
+            if RTFPARSE and (
+                mimetype == "application/rtf" or self.filepath.endswith("rtf")
+            ):
                 text_only = RtfTextOnly()
-                for line in open(self.filepath, 'r'):
+                for line in open(self.filepath, "r"):
                     text_only.feed(line)
                     text = text_only.output
             else:
                 try:
-                    f = open(self.filepath, 'r')
+                    f = open(self.filepath, "r")
                     text = f.read()
                     f.close()
                 except IOError:
-                    self.tw.showlabel('nojournal', self.filepath)
-                    debug_output("Couldn't open %s" % (self.filepath),
-                                 self.tw.running_sugar)
+                    self.tw.showlabel("nojournal", self.filepath)
+                    debug_output(
+                        "Couldn't open %s" % (self.filepath), self.tw.running_sugar
+                    )
         else:
             if description is not None:
                 text = str(description)
@@ -1448,13 +1468,15 @@ class LogoCode:
                 text = self.filepath
         if text is not None:
             self.tw.turtles.get_active_turtle().draw_text(
-                text, self.x2tx(), self.y2ty(), self.body_height, w)
+                text, self.x2tx(), self.y2ty(), self.body_height, w
+            )
 
     def media_wait(self):
         """ Wait for media to stop playing """
         if self.tw.gst_available:
             from .tagplay import media_playing
-            while (media_playing(self)):
+
+            while media_playing(self):
                 yield True
         self.ireturn()
         yield True
@@ -1463,6 +1485,7 @@ class LogoCode:
         """ Stop playing media"""
         if self.tw.gst_available:
             from .tagplay import stop_media
+
             stop_media(self)
         self.ireturn()
         yield True
@@ -1471,6 +1494,7 @@ class LogoCode:
         """ Pause media"""
         if self.tw.gst_available:
             from .tagplay import pause_media
+
             pause_media(self)
         self.ireturn()
         yield True
@@ -1479,6 +1503,7 @@ class LogoCode:
         """ Play media"""
         if self.tw.gst_available:
             from .tagplay import play_media
+
             play_media(self)
         self.ireturn()
         yield True
@@ -1487,6 +1512,7 @@ class LogoCode:
         """ Sound file from Journal """
         if self.tw.gst_available:
             from .tagplay import play_audio_from_file
+
             play_audio_from_file(self, self.filepath)
 
     def play_video(self):
@@ -1496,6 +1522,7 @@ class LogoCode:
             return
         if self.tw.gst_available:
             from .tagplay import play_movie_from_file
+
             # The video window is an overlay, so we need to know where
             # the canvas is relative to the window, e.g., which
             # toolbars, if any are open.
@@ -1505,24 +1532,25 @@ class LogoCode:
                     yoffset += GRID_CELL_SIZE
                     if self.tw.activity.toolbars_expanded():
                         yoffset += GRID_CELL_SIZE
-            play_movie_from_file(self, self.filepath, self.x2tx(),
-                                 self.y2ty() + yoffset, w, h)
+            play_movie_from_file(
+                self, self.filepath, self.x2tx(), self.y2ty() + yoffset, w, h
+            )
 
     def _expand_return(self, b, blk, blocks):
-        """ Expand a returnstack block into action name, box '__return__'
-            Parameters: the repeatstack block, the top block, all blocks.
-            Return all blocks."""
+        """Expand a returnstack block into action name, box '__return__'
+        Parameters: the repeatstack block, the top block, all blocks.
+        Return all blocks."""
 
         # We'll restore the original blocks when we are finished
         if self._save_blocks is None:
             self._save_blocks = blocks[:]
 
         # Create an action block and a box
-        action_blk = HiddenBlock('stack')
+        action_blk = HiddenBlock("stack")
         blocks.append(action_blk)
-        box_blk = HiddenBlock('box')
+        box_blk = HiddenBlock("box")
         blocks.append(box_blk)
-        box_label_blk = HiddenBlock('string', value='__return__')
+        box_label_blk = HiddenBlock("string", value="__return__")
         blocks.append(box_label_blk)
 
         # Make connections to substitute blocks
@@ -1534,7 +1562,7 @@ class LogoCode:
         tmp = b
         while tmp.connections[0] is not None:
             cblk = tmp.connections[0]
-            if cblk.docks[0][0] == 'flow':
+            if cblk.docks[0][0] == "flow":
                 break
             else:
                 tmp = cblk
@@ -1546,43 +1574,43 @@ class LogoCode:
             cblk.connections[0] = action_blk
 
         action_blk.connections.append(inflow)
-        action_blk.docks.append(['flow', True, 0, 0])
+        action_blk.docks.append(["flow", True, 0, 0])
         action_blk.connections.append(b.connections[1])
         b.connections[1].connections[0] = action_blk
-        action_blk.docks.append(['string', False, 0, 0])
+        action_blk.docks.append(["string", False, 0, 0])
         action_blk.connections.append(cblk)
-        action_blk.docks.append(['flow', False, 0, 0])
+        action_blk.docks.append(["flow", False, 0, 0])
 
         # Replace the returnstack block with a box and label.
         box_label_blk.connections.append(box_blk)
-        box_label_blk.docks.append(['string', True, 0, 0])
+        box_label_blk.docks.append(["string", True, 0, 0])
         box_blk.connections.append(b.connections[0])
         if b.connections[0] is not None:
             for i in range(len(b.connections[0].connections)):
                 if b.connections[0].connections[i] == b:
                     b.connections[0].connections[i] = box_blk
-        box_blk.docks.append(['number', True, 0, 0])
+        box_blk.docks.append(["number", True, 0, 0])
         box_blk.connections.append(box_label_blk)
-        box_blk.docks.append(['string', False, 0, 0])
+        box_blk.docks.append(["string", False, 0, 0])
 
         return action_blk, blocks
 
     def _expand_forever(self, b, blk, blocks):
-        """ Expand a while or until block into: forever, ifelse, stopstack
-            Expand a forever block to run in a separate stack
-            Parameters: the loop block, the top block, all blocks.
-            Return the start block of the expanded loop, and all blocks."""
+        """Expand a while or until block into: forever, ifelse, stopstack
+        Expand a forever block to run in a separate stack
+        Parameters: the loop block, the top block, all blocks.
+        Return the start block of the expanded loop, and all blocks."""
 
         # TODO: create a less brittle way of doing this; having to
         # manage the connections and flows locally means we may run
         # into trouble if any of these block types (forever, while,
         # until. ifelse, stopstack, or stack) is changed in tablock.py
 
-        if b.name == 'while':
+        if b.name == "while":
             while_blk = True
         else:
             while_blk = False
-        if b.name == 'until':
+        if b.name == "until":
             until_blk = True
         else:
             until_blk = False
@@ -1592,15 +1620,15 @@ class LogoCode:
             self._save_blocks = blocks[:]
 
         # Create an action block that will jump to the new stack
-        action_name = '_forever %d' % (len(self._save_while_blocks) + 1)
-        action_blk = HiddenBlock('stack')
-        action_label_blk = HiddenBlock('string', value=action_name)
+        action_name = "_forever %d" % (len(self._save_while_blocks) + 1)
+        action_blk = HiddenBlock("stack")
+        action_label_blk = HiddenBlock("string", value=action_name)
 
         # Create the blocks we'll put in the new stack
-        forever_blk = HiddenBlock('forever')
+        forever_blk = HiddenBlock("forever")
         if while_blk or until_blk:
-            ifelse_blk = HiddenBlock('ifelse')
-            stopstack_blk = HiddenBlock('stopstack')
+            ifelse_blk = HiddenBlock("ifelse")
+            stopstack_blk = HiddenBlock("stopstack")
         inflow = None
         whileflow = None
         outflow = None
@@ -1614,9 +1642,9 @@ class LogoCode:
 
         # Create action block(s) to run the code inside the forever loop
         if until_blk and whileflow is not None:  # run until flow at least once
-            action_flow_name = '_flow %d' % (len(self._save_while_blocks) + 1)
-            action_first = HiddenBlock('stack')
-            first_label_blk = HiddenBlock('string', value=action_flow_name)
+            action_flow_name = "_flow %d" % (len(self._save_while_blocks) + 1)
+            action_first = HiddenBlock("stack")
+            first_label_blk = HiddenBlock("string", value=action_flow_name)
 
         # Assign new connections and build the docks
         if inflow is not None and b in inflow.connections:
@@ -1635,50 +1663,50 @@ class LogoCode:
 
         if until_blk and whileflow is not None:
             action_first.connections.append(inflow)
-            action_first.docks.append(['flow', True, 0, 0])
+            action_first.docks.append(["flow", True, 0, 0])
             action_first.connections.append(first_label_blk)
-            action_first.docks.append(['number', False, 0, 0])
+            action_first.docks.append(["number", False, 0, 0])
             action_first.connections.append(action_blk)
-            action_first.docks.append(['flow', False, 0, 0])
+            action_first.docks.append(["flow", False, 0, 0])
             first_label_blk.connections.append(action_first)
-            first_label_blk.docks.append(['number', True, 0, 0])
+            first_label_blk.docks.append(["number", True, 0, 0])
             action_blk.connections.append(action_first)
         else:
             action_blk.connections.append(inflow)
-        action_blk.docks.append(['flow', True, 0, 0])
+        action_blk.docks.append(["flow", True, 0, 0])
         action_blk.connections.append(action_label_blk)
-        action_blk.docks.append(['number', False, 0, 0])
+        action_blk.docks.append(["number", False, 0, 0])
         action_blk.connections.append(outflow)
-        action_blk.docks.append(['flow', False, 0, 0])
+        action_blk.docks.append(["flow", False, 0, 0])
         action_label_blk.connections.append(action_blk)
-        action_label_blk.docks.append(['number', True, 0, 0])
+        action_label_blk.docks.append(["number", True, 0, 0])
 
         forever_blk.connections.append(None)
-        forever_blk.docks.append(['flow', True, 0, 0])
+        forever_blk.docks.append(["flow", True, 0, 0])
         if while_blk or until_blk:
             forever_blk.connections.append(ifelse_blk)
         else:
             forever_blk.connections.append(whileflow)
-        forever_blk.docks.append(['flow', False, 0, 0, '['])
+        forever_blk.docks.append(["flow", False, 0, 0, "["])
         forever_blk.connections.append(outflow)
-        forever_blk.docks.append(['flow', False, 0, 0, ']'])
+        forever_blk.docks.append(["flow", False, 0, 0, "]"])
         if while_blk or until_blk:
             ifelse_blk.connections.append(forever_blk)
-            ifelse_blk.docks.append(['flow', True, 0, 0])
+            ifelse_blk.docks.append(["flow", True, 0, 0])
             ifelse_blk.connections.append(boolflow)
-            ifelse_blk.docks.append(['bool', False, 0, 0])
+            ifelse_blk.docks.append(["bool", False, 0, 0])
             if while_blk:
                 ifelse_blk.connections.append(whileflow)
                 ifelse_blk.connections.append(stopstack_blk)
             else:  # until
                 ifelse_blk.connections.append(stopstack_blk)
                 ifelse_blk.connections.append(whileflow)
-            ifelse_blk.docks.append(['flow', False, 0, 0, '['])
-            ifelse_blk.docks.append(['flow', False, 0, 0, ']['])
+            ifelse_blk.docks.append(["flow", False, 0, 0, "["])
+            ifelse_blk.docks.append(["flow", False, 0, 0, "]["])
             ifelse_blk.connections.append(None)
-            ifelse_blk.docks.append(['flow', False, 0, 0, ']'])
+            ifelse_blk.docks.append(["flow", False, 0, 0, "]"])
             stopstack_blk.connections.append(ifelse_blk)
-            stopstack_blk.docks.append(['flow', False, 0, 0])
+            stopstack_blk.docks.append(["flow", False, 0, 0])
 
         if whileflow is not None:
             if while_blk or until_blk:
@@ -1695,8 +1723,7 @@ class LogoCode:
             c = whileflow.connections[0]
             whileflow.connections[0] = None
             code = self._blocks_to_code(whileflow)
-            self.stacks[self._get_stack_key(action_flow_name)] = \
-                self._readline(code)
+            self.stacks[self._get_stack_key(action_flow_name)] = self._readline(code)
             whileflow.connections[0] = c
 
         # Save the connections so we can restore them later
@@ -1714,7 +1741,7 @@ class LogoCode:
         if i == len(blocks) - 1:
             blocks_right = []
         else:
-            blocks_right = blocks[i + 1:]
+            blocks_right = blocks[i + 1 :]
         blocks = blocks_left[:]
         if until_blk and whileflow is not None:
             blocks.append(action_first)

--- a/TurtleArt/talogo.py
+++ b/TurtleArt/talogo.py
@@ -33,9 +33,11 @@ from time import time, sleep
 
 from gi.repository import GLib
 from gi.repository import GdkPixbuf
-from sugar3.graphics import style
-
-GRID_CELL_SIZE = style.GRID_CELL_SIZE
+try:
+    from sugar3.graphics import style
+    GRID_CELL_SIZE = style.GRID_CELL_SIZE
+except ImportError:
+    GRID_CELL_SIZE = 55
 
 USER_HOME = os.path.expanduser('~')
 

--- a/TurtleArt/turtleblocks.py
+++ b/TurtleArt/turtleblocks.py
@@ -34,7 +34,8 @@ import tempfile
 import subprocess
 
 import gi
-gi.require_version('Gtk', '3.0')
+
+gi.require_version("Gtk", "3.0")
 
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -45,10 +46,11 @@ from gi.repository import Gio
 try:
     # Try to use XDG Base Directory standard for config files.
     import xdg.BaseDirectory
-    CONFIG_HOME = os.path.join(xdg.BaseDirectory.xdg_config_home, 'turtleart')
+
+    CONFIG_HOME = os.path.join(xdg.BaseDirectory.xdg_config_home, "turtleart")
 except ImportError:
     # Default to `.config` per the spec.
-    CONFIG_HOME = os.path.expanduser(os.path.join('~', '.config', 'turtleart'))
+    CONFIG_HOME = os.path.expanduser(os.path.join("~", ".config", "turtleart"))
 
 argv = sys.argv[:]  # Workaround for import behavior of gst in tagplay
 sys.argv[1:] = []  # Execution of import gst cannot see '--help' or '-h'
@@ -56,67 +58,88 @@ sys.argv[1:] = []  # Execution of import gst cannot see '--help' or '-h'
 import gettext
 from gettext import gettext as _
 
-from TurtleArt.taconstants import (OVERLAY_LAYER, DEFAULT_TURTLE_COLORS,
-                                   TAB_LAYER, SUFFIX, TMP_SVG_PATH,
-                                   TMP_ODP_PATH, PASTE_OFFSET)
-from TurtleArt.tautils import (data_from_string, get_load_name,
-                               get_path, get_save_name, is_writeable)
+from TurtleArt.taconstants import (
+    OVERLAY_LAYER,
+    DEFAULT_TURTLE_COLORS,
+    TAB_LAYER,
+    SUFFIX,
+    TMP_SVG_PATH,
+    TMP_ODP_PATH,
+    PASTE_OFFSET,
+)
+from TurtleArt.tautils import (
+    data_from_string,
+    get_load_name,
+    get_path,
+    get_save_name,
+    is_writeable,
+)
 from TurtleArt.tapalette import default_values
 from TurtleArt.tawindow import TurtleArtWindow
 from TurtleArt.taexportlogo import save_logo
 from TurtleArt.taexportpython import save_python
 from TurtleArt.taprimitive import PyExportError
-from TurtleArt.taplugin import (load_a_plugin, cancel_plugin_install,
-                                complete_plugin_install)
+from TurtleArt.taplugin import (
+    load_a_plugin,
+    cancel_plugin_install,
+    complete_plugin_install,
+)
 
-from TurtleArt.util.menubuilder import (make_menu_item,
-                                        make_sub_menu, make_checkmenu_item)
+from TurtleArt.util.menubuilder import (
+    make_menu_item,
+    make_sub_menu,
+    make_checkmenu_item,
+)
 
 
-class TurtleMain():
+class TurtleMain:
 
-    ''' Launch Turtle Art in GNOME (from outside of Sugar). '''
-    _INSTALL_PATH = '/usr/share/sugar/activities/TurtleArt.activity'
-    _ALTERNATIVE_INSTALL_PATH = \
-        '/usr/local/share/sugar/activities/TurtleArt.activity'
-    _ICON_SUBPATH = 'images/turtle.png'
-    _GNOME_PLUGIN_SUBPATH = 'gnome_plugins'
-    _GIO_SETTINGS = 'org.laptop.TurtleArtActivity'
-    _HOVER_HELP = 'hover-help'
-    _ORIENTATION = 'palette-orientation'
-    _COORDINATE_SCALE = 'coordinate-scale'
-    _PLUGINS_LIST = 'plugins'
+    """ Launch Turtle Art in GNOME (from outside of Sugar). """
+
+    _INSTALL_PATH = "/usr/share/sugar/activities/TurtleArt.activity"
+    _ALTERNATIVE_INSTALL_PATH = "/usr/local/share/sugar/activities/TurtleArt.activity"
+    _ICON_SUBPATH = "images/turtle.png"
+    _GNOME_PLUGIN_SUBPATH = "gnome_plugins"
+    _GIO_SETTINGS = "org.laptop.TurtleArtActivity"
+    _HOVER_HELP = "hover-help"
+    _ORIENTATION = "palette-orientation"
+    _COORDINATE_SCALE = "coordinate-scale"
+    _PLUGINS_LIST = "plugins"
 
     def __init__(self, lib_path, share_path):
         self._gio_settings_overrides = False
 
         self._lib_path = lib_path
         self._share_path = share_path
-        self._abspath = os.path.abspath('.')
+        self._abspath = os.path.abspath(".")
 
         file_activity_info = configparser.ConfigParser()
-        activity_info_path = os.path.join(share_path, 'activity/activity.info')
+        activity_info_path = os.path.join(share_path, "activity/activity.info")
         file_activity_info.read(activity_info_path)
-        bundle_id = file_activity_info.get('Activity', 'bundle_id')
-        self.version = file_activity_info.get('Activity', 'activity_version')
-        self.name = file_activity_info.get('Activity', 'name')
-        self.summary = file_activity_info.get('Activity', 'summary')
-        self.website = file_activity_info.get('Activity', 'url')
-        self.icon_name = file_activity_info.get('Activity', 'icon')
+        bundle_id = file_activity_info.get("Activity", "bundle_id")
+        self.version = file_activity_info.get("Activity", "activity_version")
+        self.name = file_activity_info.get("Activity", "name")
+        self.summary = file_activity_info.get("Activity", "summary")
+        self.website = file_activity_info.get("Activity", "url")
+        self.icon_name = file_activity_info.get("Activity", "icon")
 
-        path = os.path.join(share_path, 'locale')
+        path = os.path.join(share_path, "locale")
         if os.path.isdir(path):
             gettext.bindtextdomain(bundle_id, path)
         gettext.textdomain(bundle_id)
         global _
         _ = gettext.gettext
-        self._HELP_MSG = 'turtleblocks.py: ' + _('usage is') + '''
+        self._HELP_MSG = (
+            "turtleblocks.py: "
+            + _("usage is")
+            + """
  \tturtleblocks.py
  \tturtleblocks.py project.tb
  \tturtleblocks.py --output_png project.tb
  \tturtleblocks.py -o project
  \tturtleblocks.py --run project.tb
- \tturtleblocks.py -r project'''
+ \tturtleblocks.py -r project"""
+        )
         self._init_vars()
         self._parse_command_line()
         self._ensure_sugar_paths()
@@ -140,23 +163,22 @@ class TurtleMain():
             self._start_gtk()
 
     def _get_local_settings(self, activity_root):
-        """ return an activity-specific Gio.Settings
-        """
+        """return an activity-specific Gio.Settings"""
         # create compiled schema file if missing from activity root
-        compiled = os.path.join(activity_root, 'gschemas.compiled')
+        compiled = os.path.join(activity_root, "gschemas.compiled")
         if not os.access(compiled, os.R_OK):
             # create schemas directory if missing
-            path = os.path.join(get_path(None, 'data'), 'schemas')
+            path = os.path.join(get_path(None, "data"), "schemas")
             if not os.access(path, os.F_OK):
                 os.makedirs(path)
 
             # create compiled schema file if missing
-            compiled = os.path.join(path, 'gschemas.compiled')
+            compiled = os.path.join(path, "gschemas.compiled")
             if not os.access(compiled, os.R_OK):
-                src = '%s.gschema.xml' % self._GIO_SETTINGS
-                lines = open(os.path.join(activity_root, src), 'r').readlines()
-                open(os.path.join(path, src), 'w').writelines(lines)
-                os.system('glib-compile-schemas %s' % path)
+                src = "%s.gschema.xml" % self._GIO_SETTINGS
+                lines = open(os.path.join(activity_root, src), "r").readlines()
+                open(os.path.join(path, src), "w").writelines(lines)
+                os.system("glib-compile-schemas %s" % path)
                 os.remove(os.path.join(path, src))
 
             schemas_path = path
@@ -164,8 +186,7 @@ class TurtleMain():
             schemas_path = activity_root
 
         # create a local Gio.Settings based on the compiled schema
-        source = Gio.SettingsSchemaSource.new_from_directory(
-            schemas_path, None, True)
+        source = Gio.SettingsSchemaSource.new_from_directory(schemas_path, None, True)
         schema = source.lookup(self._GIO_SETTINGS, True)
         _settings = Gio.Settings.new_full(schema, None, None)
         return _settings
@@ -177,45 +198,47 @@ class TurtleMain():
         return CONFIG_HOME
 
     def _get_gnome_plugin_home(self):
-        ''' Use plugin directory associated with execution path. '''
-        if os.path.exists(os.path.join(self._lib_path,
-                                       self._GNOME_PLUGIN_SUBPATH)):
+        """ Use plugin directory associated with execution path. """
+        if os.path.exists(os.path.join(self._lib_path, self._GNOME_PLUGIN_SUBPATH)):
             return os.path.join(self._lib_path, self._GNOME_PLUGIN_SUBPATH)
         else:
             return None
 
     def _get_plugin_candidates(self, path):
-        ''' Look for plugin files in plugin directory. '''
+        """ Look for plugin files in plugin directory. """
         plugin_files = []
         if path is not None:
             candidates = os.listdir(path)
             for c in candidates:
-                if c[-10:] == '_plugin.py' and c[0] != '#' and c[0] != '.':
-                    plugin_files.append(c.split('.')[0])
+                if c[-10:] == "_plugin.py" and c[0] != "#" and c[0] != ".":
+                    plugin_files.append(c.split(".")[0])
         return plugin_files
 
     def _init_gnome_plugins(self):
-        ''' Try launching any plugins we may have found. '''
+        """ Try launching any plugins we may have found. """
         for p in self._get_plugin_candidates(self._get_gnome_plugin_home()):
             P = p.capitalize()
-            f = "def f(self): from gnome_plugins.%s import %s; \
-return %s(self)" % (p, P, P)
+            f = (
+                "def f(self): from gnome_plugins.%s import %s; \
+return %s(self)"
+                % (p, P, P)
+            )
             plugin = {}
             try:
                 exec(f, globals(), plugin)
                 self._gnome_plugins.append(list(plugin.values())[0](self))
             except ImportError as e:
-                print('failed to import %s: %s' % (P, str(e)))
+                print("failed to import %s: %s" % (P, str(e)))
             except ValueError as e:
-                print('failed to import %s: %s' % (P, str(e)))
+                print("failed to import %s: %s" % (P, str(e)))
 
     def _run_gnome_plugins(self):
-        ''' Tell the plugin about the TurtleWindow instance. '''
+        """ Tell the plugin about the TurtleWindow instance. """
         for p in self._gnome_plugins:
             p.set_tw(self.tw)
 
     def _mkdir_p(self, path):
-        '''Create a directory in a fashion similar to `mkdir -p`.'''
+        """Create a directory in a fashion similar to `mkdir -p`."""
         try:
             os.makedirs(path)
         except OSError as exc:
@@ -225,21 +248,20 @@ return %s(self)" % (p, P, P)
                 raise
 
     def _makepath(self, path):
-        ''' Make a path if it doesn't previously exist '''
+        """ Make a path if it doesn't previously exist """
         dpath = os.path.normpath(os.path.dirname(path))
         if not os.path.exists(dpath):
             os.makedirs(dpath)
 
     def _start_gtk(self):
-        ''' Get a main window set up. '''
-        self.win.connect('configure_event', self.tw.update_overlay_position)
+        """ Get a main window set up. """
+        self.win.connect("configure_event", self.tw.update_overlay_position)
         self.tw.parent = self.win
         self.init_complete = True
         if self._ta_file is None:
             self.tw.load_start()
         else:
-            self.win.get_window().set_cursor(
-                Gdk.Cursor.new(Gdk.CursorType.WATCH))
+            self.win.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
             GLib.idle_add(self._project_loader, self._ta_file)
         self._set_gio_settings_overrides()
         Gtk.main()
@@ -249,26 +271,24 @@ return %s(self)" % (p, P, P)
         self.tw.lc.trace = 0
         if self._run_on_launch:
             self._do_run_cb()
-        self.win.get_window().set_cursor(
-            Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
+        self.win.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
 
     def _draw_and_quit(self):
-        ''' Non-interactive mode: run the project, save it to a file
-        and quit. '''
+        """Non-interactive mode: run the project, save it to a file
+        and quit."""
         self.tw.load_start(self._ta_file)
         self.tw.lc.trace = 0
         self.tw.run_button(0, running_from_button_push=True)
         self.tw.save_as_image(self._ta_file)
 
     def _build_window(self, interactive=True):
-        ''' Initialize the TurtleWindow instance. '''
+        """ Initialize the TurtleWindow instance. """
         if interactive:
             win = self.canvas.get_window()
             cr = win.cairo_create()
             surface = cr.get_target()
         else:
-            img_surface = cairo.ImageSurface(cairo.FORMAT_RGB24,
-                                             1024, 768)
+            img_surface = cairo.ImageSurface(cairo.FORMAT_RGB24, 1024, 768)
             cr = cairo.Context(img_surface)
             surface = cr.get_target()
         self.turtle_canvas = surface.create_similar(
@@ -276,20 +296,22 @@ return %s(self)" % (p, P, P)
             # max(1024,  Gdk.Screen.width() * 2),
             # max(768, Gdk.Screen.height() * 2))
             Gdk.Screen.width() * 2,
-            Gdk.Screen.height() * 2)
+            Gdk.Screen.height() * 2,
+        )
 
         # Make sure the autosave directory is writeable
         if is_writeable(self._share_path):
             self._autosavedirname = self._share_path
         else:
-            self._autosavedirname = os.path.expanduser('~')
+            self._autosavedirname = os.path.expanduser("~")
         self.tw = TurtleArtWindow(
             self.canvas,
             self._lib_path,
             self._share_path,
             turtle_canvas=self.turtle_canvas,
             activity=self,
-            running_sugar=False)
+            running_sugar=False,
+        )
         self.tw.save_folder = self._abspath  # os.path.expanduser('~')
 
         if interactive:
@@ -317,8 +339,8 @@ return %s(self)" % (p, P, P)
             self._gio_settings_overrides = False
 
     def _init_vars(self):
-        ''' If we are invoked to start a project from Gnome, we should make
-        sure our current directory is TA's source dir. '''
+        """If we are invoked to start a project from Gnome, we should make
+        sure our current directory is TA's source dir."""
         self._ta_file = None
         self._output_png = False
         self._run_on_launch = False
@@ -328,25 +350,24 @@ return %s(self)" % (p, P, P)
         self.init_complete = False
 
     def _parse_command_line(self):
-        ''' Try to make sense of the command-line arguments. '''
+        """ Try to make sense of the command-line arguments. """
         try:
-            opts, args = getopt.getopt(argv[1:], 'hor',
-                                       ['help', 'output_png', 'run'])
+            opts, args = getopt.getopt(argv[1:], "hor", ["help", "output_png", "run"])
         except getopt.GetoptError as err:
             print(str(err))
             print(self._HELP_MSG)
             sys.exit(2)
         self._run_on_launch = False
         for o, a in opts:
-            if o in ('-h', '--help'):
+            if o in ("-h", "--help"):
                 print(self._HELP_MSG)
                 sys.exit()
-            if o in ('-o', '--output_png'):
+            if o in ("-o", "--output_png"):
                 self._output_png = True
-            elif o in ('-r', '--run'):
+            elif o in ("-r", "--run"):
                 self._run_on_launch = True
             else:
-                assert False, _('No option action:') + ' ' + o
+                assert False, _("No option action:") + " " + o
         if args:
             self._ta_file = args[0]
 
@@ -356,41 +377,44 @@ return %s(self)" % (p, P, P)
 
         if self._ta_file is not None:
             if not self._ta_file.endswith(SUFFIX):
-                self._ta_file += '.tb'
+                self._ta_file += ".tb"
             if not os.path.exists(self._ta_file):
                 self._ta_file = os.path.join(self._abspath, self._ta_file)
                 if not os.path.exists(self._ta_file):
-                    assert False, ('%s: %s' %
-                                   (self._ta_file, _('File not found')))
+                    assert False, "%s: %s" % (self._ta_file, _("File not found"))
 
     def _ensure_sugar_paths(self):
-        ''' Make sure Sugar paths are present. '''
-        tapath = os.path.join(os.environ['HOME'], '.sugar', 'default',
-                              'org.laptop.TurtleArtActivity')
-        list(map(self._makepath, (os.path.join(tapath, 'data/'),
-                                  os.path.join(tapath, 'instance/'))))
+        """ Make sure Sugar paths are present. """
+        tapath = os.path.join(
+            os.environ["HOME"], ".sugar", "default", "org.laptop.TurtleArtActivity"
+        )
+        list(
+            map(
+                self._makepath,
+                (os.path.join(tapath, "data/"), os.path.join(tapath, "instance/")),
+            )
+        )
 
     def _read_initial_pos(self):
-        ''' Read saved configuration. '''
+        """ Read saved configuration. """
         try:
-            data_file = open(os.path.join(CONFIG_HOME, 'turtleartrc'), 'r')
+            data_file = open(os.path.join(CONFIG_HOME, "turtleartrc"), "r")
         except IOError:
             # Opening the config file failed
             # We'll assume it needs to be created
             try:
                 self._mkdir_p(CONFIG_HOME)
-                data_file = open(os.path.join(CONFIG_HOME, 'turtleartrc'),
-                                 'a+')
+                data_file = open(os.path.join(CONFIG_HOME, "turtleartrc"), "a+")
             except IOError as e:
                 # We can't write to the configuration file, use
                 # a faux file that will persist for the length of
                 # the session.
-                print(_('Configuration directory not writable: %s') % (e))
+                print(_("Configuration directory not writable: %s") % (e))
             data_file = io.StringIO()
-            data_file.write(str(50) + '\n')
-            data_file.write(str(50) + '\n')
-            data_file.write(str(800) + '\n')
-            data_file.write(str(550) + '\n')
+            data_file.write(str(50) + "\n")
+            data_file.write(str(50) + "\n")
+            data_file.write(str(800) + "\n")
+            data_file.write(str(550) + "\n")
             data_file.seek(0)
         try:
             self.x = int(data_file.readline())
@@ -404,43 +428,41 @@ return %s(self)" % (p, P, P)
             self.height = 550
 
     def _fixed_resize_cb(self, widget=None, rect=None):
-        ''' If a toolbar opens or closes, we need to resize the vbox
-        holding out scrolling window. '''
+        """If a toolbar opens or closes, we need to resize the vbox
+        holding out scrolling window."""
         self.vbox.set_size_request(rect.width, rect.height)
         self.menu_height = self.menu_bar.get_size_request()[1]
 
     def restore_cursor(self):
-        ''' No longer copying or sharing, so restore standard cursor. '''
+        """ No longer copying or sharing, so restore standard cursor. """
         self.tw.copying_blocks = False
         self.tw.sharing_blocks = False
         self.tw.saving_blocks = False
         self.tw.deleting_blocks = False
-        if hasattr(self, 'get_window'):
-            if hasattr(self.get_window(), 'get_cursor'):
+        if hasattr(self, "get_window"):
+            if hasattr(self.get_window(), "get_cursor"):
                 self.get_window().set_cursor(self._old_cursor)
             else:
-                self.get_window().set_cursor(
-                    Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
+                self.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
 
     def _setup_gtk(self):
-        ''' Set up a scrolled window in which to run Turtle Blocks. '''
+        """ Set up a scrolled window in which to run Turtle Blocks. """
         win = Gtk.Window(Gtk.WindowType.TOPLEVEL)
         win.set_default_size(self.width, self.height)
         win.move(self.x, self.y)
         win.maximize()
-        win.set_title('%s %s' % (self.name, str(self.version)))
+        win.set_title("%s %s" % (self.name, str(self.version)))
         if os.path.exists(os.path.join(self._share_path, self._ICON_SUBPATH)):
-            win.set_icon_from_file(os.path.join(self._share_path,
-                                                self._ICON_SUBPATH))
+            win.set_icon_from_file(os.path.join(self._share_path, self._ICON_SUBPATH))
         win.show()
-        win.connect('delete_event', self._quit_ta)
+        win.connect("delete_event", self._quit_ta)
 
-        ''' Create a scrolled window to contain the turtle canvas. We
+        """ Create a scrolled window to contain the turtle canvas. We
         add a Fixed container in order to position text Entry widgets
-        on top of string and number blocks.'''
+        on top of string and number blocks."""
 
         self.fixed = Gtk.Fixed()
-        self.fixed.connect('size-allocate', self._fixed_resize_cb)
+        self.fixed.connect("size-allocate", self._fixed_resize_cb)
         width = Gdk.Screen.width() - 80
         height = Gdk.Screen.height() - 80
         self.fixed.set_size_request(width, height)
@@ -472,92 +494,75 @@ return %s(self)" % (p, P, P)
         self.canvas = canvas
 
     def _get_menu_bar(self):
-        ''' Instead of Sugar toolbars, use GNOME menus. '''
+        """ Instead of Sugar toolbars, use GNOME menus. """
         menu = Gtk.Menu()
-        make_menu_item(menu, _('New'), self._do_new_cb)
-        make_menu_item(menu, _('Show sample projects'),
-                       self._create_store)
-        make_menu_item(menu, _('Open'), self._do_open_cb)
-        make_menu_item(menu, _('Add project'), self._do_load_cb)
-        make_menu_item(menu, _('Load plugin'),
-                       self._do_load_plugin_cb)
-        make_menu_item(menu, _('Save'), self._do_save_cb)
-        make_menu_item(menu, _('Save as'), self._do_save_as_cb)
+        make_menu_item(menu, _("New"), self._do_new_cb)
+        make_menu_item(menu, _("Show sample projects"), self._create_store)
+        make_menu_item(menu, _("Open"), self._do_open_cb)
+        make_menu_item(menu, _("Add project"), self._do_load_cb)
+        make_menu_item(menu, _("Load plugin"), self._do_load_plugin_cb)
+        make_menu_item(menu, _("Save"), self._do_save_cb)
+        make_menu_item(menu, _("Save as"), self._do_save_as_cb)
 
         # export submenu
         export_submenu = Gtk.Menu()
-        export_menu = make_sub_menu(export_submenu, _('Export as'))
+        export_menu = make_sub_menu(export_submenu, _("Export as"))
         menu.append(export_menu)
 
-        make_menu_item(export_submenu, _('image'),
-                       self._do_save_picture_cb)
-        make_menu_item(export_submenu, _('image (blocks)'),
-                       self._do_save_blocks_image_cb)
-        make_menu_item(export_submenu, _('SVG'),
-                       self._do_save_svg_cb)
-        make_menu_item(export_submenu, _('icon'),
-                       self._do_save_as_icon_cb)
+        make_menu_item(export_submenu, _("image"), self._do_save_picture_cb)
+        make_menu_item(
+            export_submenu, _("image (blocks)"), self._do_save_blocks_image_cb
+        )
+        make_menu_item(export_submenu, _("SVG"), self._do_save_svg_cb)
+        make_menu_item(export_submenu, _("icon"), self._do_save_as_icon_cb)
         # TRANS: ODP is Open Office presentation
-        make_menu_item(export_submenu, _('ODP'),
-                       self._do_save_as_odp_cb)
-        make_menu_item(export_submenu, _('Logo'),
-                       self._do_save_logo_cb)
-        make_menu_item(export_submenu, _('Python'),
-                       self._do_save_python_cb)
-        make_menu_item(menu, _('Quit'), self._quit_ta)
-        activity_menu = make_sub_menu(menu, _('File'))
+        make_menu_item(export_submenu, _("ODP"), self._do_save_as_odp_cb)
+        make_menu_item(export_submenu, _("Logo"), self._do_save_logo_cb)
+        make_menu_item(export_submenu, _("Python"), self._do_save_python_cb)
+        make_menu_item(menu, _("Quit"), self._quit_ta)
+        activity_menu = make_sub_menu(menu, _("File"))
 
         menu = Gtk.Menu()
-        make_menu_item(menu, _('Cartesian coordinates'),
-                       self._do_cartesian_cb)
-        make_menu_item(menu, _('Polar coordinates'),
-                       self._do_polar_cb)
+        make_menu_item(menu, _("Cartesian coordinates"), self._do_cartesian_cb)
+        make_menu_item(menu, _("Polar coordinates"), self._do_polar_cb)
         self.coords = make_checkmenu_item(
-            menu, _('Rescale coordinates'),
-            self._do_rescale_cb, status=False)
-        make_menu_item(menu, _('Grow blocks'),
-                       self._do_resize_cb, 1.5)
-        make_menu_item(menu, _('Shrink blocks'),
-                       self._do_resize_cb, 0.667)
-        make_menu_item(menu, _('Reset block size'),
-                       self._do_resize_cb, -1)
+            menu, _("Rescale coordinates"), self._do_rescale_cb, status=False
+        )
+        make_menu_item(menu, _("Grow blocks"), self._do_resize_cb, 1.5)
+        make_menu_item(menu, _("Shrink blocks"), self._do_resize_cb, 0.667)
+        make_menu_item(menu, _("Reset block size"), self._do_resize_cb, -1)
         self.hover = make_checkmenu_item(
-            menu, _('Turn on hover help'),
-            self._do_toggle_hover_help_cb, status=True)
-        view_menu = make_sub_menu(menu, _('View'))
+            menu, _("Turn on hover help"), self._do_toggle_hover_help_cb, status=True
+        )
+        view_menu = make_sub_menu(menu, _("View"))
 
         menu = Gtk.Menu()
-        make_menu_item(menu, _('Copy'), self._do_copy_cb)
-        make_menu_item(menu, _('Paste'), self._do_paste_cb)
-        make_menu_item(menu, _('Save stack'),
-                       self._do_save_macro_cb)
-        make_menu_item(menu, _('Delete stack'),
-                       self._do_delete_macro_cb)
-        edit_menu = make_sub_menu(menu, _('Edit'))
+        make_menu_item(menu, _("Copy"), self._do_copy_cb)
+        make_menu_item(menu, _("Paste"), self._do_paste_cb)
+        make_menu_item(menu, _("Save stack"), self._do_save_macro_cb)
+        make_menu_item(menu, _("Delete stack"), self._do_delete_macro_cb)
+        edit_menu = make_sub_menu(menu, _("Edit"))
 
         menu = Gtk.Menu()
-        make_menu_item(menu, _('Show palette'),
-                       self._do_palette_cb)
-        make_menu_item(menu, _('Hide palette'),
-                       self._do_hide_palette_cb)
-        make_menu_item(menu, _('Show/hide blocks'),
-                       self._do_hideshow_cb)
-        tool_menu = make_sub_menu(menu, _('Tools'))
+        make_menu_item(menu, _("Show palette"), self._do_palette_cb)
+        make_menu_item(menu, _("Hide palette"), self._do_hide_palette_cb)
+        make_menu_item(menu, _("Show/hide blocks"), self._do_hideshow_cb)
+        tool_menu = make_sub_menu(menu, _("Tools"))
 
         menu = Gtk.Menu()
-        make_menu_item(menu, _('Clean'), self._do_eraser_cb)
-        make_menu_item(menu, _('Run'), self._do_run_cb)
-        make_menu_item(menu, _('Step'), self._do_step_cb)
-        make_menu_item(menu, _('Debug'), self._do_trace_cb)
-        make_menu_item(menu, _('Stop'), self._do_stop_cb)
-        turtle_menu = make_sub_menu(menu, _('Turtle'))
+        make_menu_item(menu, _("Clean"), self._do_eraser_cb)
+        make_menu_item(menu, _("Run"), self._do_run_cb)
+        make_menu_item(menu, _("Step"), self._do_step_cb)
+        make_menu_item(menu, _("Debug"), self._do_trace_cb)
+        make_menu_item(menu, _("Stop"), self._do_stop_cb)
+        turtle_menu = make_sub_menu(menu, _("Turtle"))
 
         self._plugin_menu = Gtk.Menu()
-        plugin_men = make_sub_menu(self._plugin_menu, _('Plugins'))
+        plugin_men = make_sub_menu(self._plugin_menu, _("Plugins"))
 
         menu = Gtk.Menu()
-        make_menu_item(menu, _('About...'), self._do_about_cb)
-        help_menu = make_sub_menu(menu, _('Help'))
+        make_menu_item(menu, _("About..."), self._do_about_cb)
+        help_menu = make_sub_menu(menu, _("Help"))
 
         menu_bar = Gtk.MenuBar()
         menu_bar.append(activity_menu)
@@ -578,7 +583,7 @@ return %s(self)" % (p, P, P)
         return menu_bar
 
     def _quit_ta(self, widget=None, e=None):
-        ''' Save changes on exit '''
+        """ Save changes on exit """
         project_empty = self.tw.is_project_empty()
         if not project_empty:
             resp = self._show_save_dialog(e is None)
@@ -591,11 +596,11 @@ return %s(self)" % (p, P, P)
             elif resp == Gtk.ResponseType.CANCEL:
                 return
 
-        if hasattr(self, '_settings'):
+        if hasattr(self, "_settings"):
             self._settings.set_int(self._ORIENTATION, self.tw.orientation)
 
         for plugin in list(self.tw.turtleart_plugins.values()):
-            if hasattr(plugin, 'quit'):
+            if hasattr(plugin, "quit"):
                 plugin.quit()
 
         # Clean up temporary files
@@ -612,74 +617,84 @@ return %s(self)" % (p, P, P)
         exit()
 
     def _show_save_dialog(self, add_cancel=False):
-        ''' Dialog for save project '''
-        dlg = Gtk.MessageDialog(parent=None, type=Gtk.MessageType.INFO,
-                                buttons=Gtk.ButtonsType.YES_NO,
-                                message_format=_('You have unsaved work. \
-Would you like to save before quitting?'))
+        """ Dialog for save project """
+        dlg = Gtk.MessageDialog(
+            parent=None,
+            type=Gtk.MessageType.INFO,
+            buttons=Gtk.ButtonsType.YES_NO,
+            message_format=_(
+                "You have unsaved work. \
+Would you like to save before quitting?"
+            ),
+        )
         dlg.set_default_response(Gtk.ResponseType.YES)
         if add_cancel:
             dlg.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        dlg.set_title(_('Save project?'))
-        dlg.set_property('skip-taskbar-hint', False)
+        dlg.set_title(_("Save project?"))
+        dlg.set_property("skip-taskbar-hint", False)
 
         resp = dlg.run()
         dlg.destroy()
         return resp
 
-    def _reload_plugin_alert(self, tmp_dir, tmp_path, plugin_path, plugin_name,
-                             file_info):
+    def _reload_plugin_alert(
+        self, tmp_dir, tmp_path, plugin_path, plugin_name, file_info
+    ):
         print("Already installed")
-        title = _('Plugin %s already installed') % plugin_name
-        msg = _('Do you want to reinstall %s?') % plugin_name
-        dlg = Gtk.MessageDialog(parent=None, type=Gtk.MessageType.INFO,
-                                buttons=Gtk.ButtonsType.YES_NO,
-                                message_format=title)
+        title = _("Plugin %s already installed") % plugin_name
+        msg = _("Do you want to reinstall %s?") % plugin_name
+        dlg = Gtk.MessageDialog(
+            parent=None,
+            type=Gtk.MessageType.INFO,
+            buttons=Gtk.ButtonsType.YES_NO,
+            message_format=title,
+        )
         dlg.format_secondary_text(msg)
         dlg.set_title(title)
-        dlg.set_property('skip-taskbar-hint', False)
+        dlg.set_property("skip-taskbar-hint", False)
 
         resp = dlg.run()
         dlg.destroy()
 
         if resp is Gtk.ResponseType.OK:
-            complete_plugin_install(self, tmp_dir, tmp_path, plugin_path,
-                                    plugin_name, file_info)
+            complete_plugin_install(
+                self, tmp_dir, tmp_path, plugin_path, plugin_name, file_info
+            )
         elif resp is Gtk.ResponseType.CANCEL:
             cancel_plugin_install(tmp_dir)
 
     def _do_new_cb(self, widget):
-        ''' Callback for new project. '''
+        """ Callback for new project. """
         self.tw.new_project()
         self.tw.load_start()
 
     def _do_open_cb(self, widget):
-        ''' Callback for open project. '''
+        """ Callback for open project. """
         self.tw.load_file_from_chooser(True)
 
     def _do_load_cb(self, widget):
-        ''' Callback for load project (add to current project). '''
+        """ Callback for load project (add to current project). """
         self.tw.load_file_from_chooser(False)
 
     def _do_load_plugin_cb(self, widget):
-        file_path, loaddir = get_load_name('.tar.gz')
+        file_path, loaddir = get_load_name(".tar.gz")
         if file_path is None:
             return
         try:
             # Copy to tmp file since some systems had trouble
             # with gunzip directly from datastore
-            datapath = get_path(None, 'instance')
+            datapath = get_path(None, "instance")
             if not os.path.exists(datapath):
                 os.makedirs(datapath)
-            tmpfile = os.path.join(datapath, 'tmpfile.tar.gz')
-            subprocess.call(['cp', file_path, tmpfile])
-            status = subprocess.call(['gunzip', tmpfile])
+            tmpfile = os.path.join(datapath, "tmpfile.tar.gz")
+            subprocess.call(["cp", file_path, tmpfile])
+            status = subprocess.call(["gunzip", tmpfile])
             if status == 0:
-                tar_fd = tarfile.open(tmpfile[:-3], 'r')
+                tar_fd = tarfile.open(tmpfile[:-3], "r")
             else:
-                tar_fd = tarfile.open(tmpfile, 'r')
+                tar_fd = tarfile.open(tmpfile, "r")
         except BaseException:
-            tar_fd = tarfile.open(file_path, 'r')
+            tar_fd = tarfile.open(file_path, "r")
 
         tmp_dir = tempfile.mkdtemp()
 
@@ -692,83 +707,82 @@ Would you like to save before quitting?'))
         finally:
             tar_fd.close()
             # Remove tmpfile.tar
-            subprocess.call(['rm',
-                             os.path.join(datapath, 'tmpfile.tar')])
+            subprocess.call(["rm", os.path.join(datapath, "tmpfile.tar")])
 
     def _do_save_cb(self, widget):
-        ''' Callback for save project. '''
+        """ Callback for save project. """
         self.tw.save_file(self._ta_file)
 
     def _do_save_as_cb(self, widget):
-        ''' Callback for save-as project. '''
+        """ Callback for save-as project. """
         self._save_as()
 
     def autosave(self):
-        ''' Autosave is called each type the run button is pressed '''
+        """ Autosave is called each type the run button is pressed """
         temp_load_save_folder = self.tw.load_save_folder
         temp_save_folder = self.tw.save_folder
         self.tw.load_save_folder = self._autosavedirname
         self.tw.save_folder = self._autosavedirname
-        self.tw.save_file(file_name=os.path.join(
-            self._autosavedirname, 'autosave.tb'))
+        self.tw.save_file(file_name=os.path.join(self._autosavedirname, "autosave.tb"))
         self.tw.save_folder = temp_save_folder
         self.tw.load_save_folder = temp_load_save_folder
 
     def _save_as(self):
-        ''' Save as is called from callback and quit '''
+        """ Save as is called from callback and quit """
         self.tw.save_file_name = self._ta_file
         self.tw.save_file()
 
     def _save_changes(self):
-        ''' Save changes to current project '''
+        """ Save changes to current project """
         self.tw.save_file_name = self._ta_file
         self.tw.save_file(self.tw._loaded_project)
 
     def _do_save_blocks_image_cb(self, widget):
-        ''' Callback for save blocks as image. '''
+        """ Callback for save blocks as image. """
         self.tw.save_blocks_as_image()
 
     def _do_save_picture_cb(self, widget):
-        ''' Callback for save canvas. '''
+        """ Callback for save canvas. """
         self.tw.save_as_image()
 
     def _do_save_svg_cb(self, widget):
-        ''' Callback for save canvas as SVG. '''
+        """ Callback for save canvas as SVG. """
         self.tw.save_as_image(svg=True)
 
     def _do_save_as_icon_cb(self, widget):
-        ''' Callback for save canvas. '''
+        """ Callback for save canvas. """
         self.tw.write_svg_operation()
         self.tw.save_as_icon()
 
     def _do_save_as_odp_cb(self, widget):
-        ''' Callback for save canvas. '''
+        """ Callback for save canvas. """
         self.tw.save_as_odp()
 
     def _do_save_logo_cb(self, widget):
-        ''' Callback for save project to Logo. '''
+        """ Callback for save project to Logo. """
         logocode = save_logo(self.tw)
         if len(logocode) == 0:
             return
-        save_type = '.lg'
+        save_type = ".lg"
         filename, self.tw.load_save_folder = get_save_name(
-            save_type, None, 'logosession')
+            save_type, None, "logosession"
+        )
         if isinstance(filename, str):
-            filename = filename.encode('utf-8')
+            filename = filename.encode("utf-8")
         if filename is not None:
-            f = open(filename, 'w')
+            f = open(filename, "w")
             f.write(logocode)
             f.close()
 
     def _do_save_python_cb(self, widget):
-        ''' Callback for saving the project as Python code. '''
+        """ Callback for saving the project as Python code. """
         # catch PyExportError and display a user-friendly message instead
         try:
             pythoncode = save_python(self.tw)
         except PyExportError as pyee:
             if pyee.block is not None:
                 pyee.block.highlight()
-            self.tw.showlabel('status', str(pyee))
+            self.tw.showlabel("status", str(pyee))
             print(pyee)
             return
         if not pythoncode:
@@ -779,18 +793,19 @@ Would you like to save before quitting?'))
             default_name = _("myproject")
         elif default_name.endswith(".ta") or default_name.endswith(".tb"):
             default_name = default_name[:-3]
-        save_type = '.py'
+        save_type = ".py"
         filename, self.tw.load_save_folder = get_save_name(
-            save_type, None, default_name)
+            save_type, None, default_name
+        )
         if isinstance(filename, str):
-            filename = filename.encode('utf-8')
+            filename = filename.encode("utf-8")
         if filename is not None:
-            f = open(filename, 'w')
+            f = open(filename, "w")
             f.write(pythoncode)
             f.close()
 
     def _do_resize_cb(self, widget, factor):
-        ''' Callback to resize blocks. '''
+        """ Callback to resize blocks. """
         if factor == -1:
             self.tw.block_scale = 2.0
         else:
@@ -798,47 +813,45 @@ Would you like to save before quitting?'))
         self.tw.resize_blocks()
 
     def _do_cartesian_cb(self, button):
-        ''' Callback to display/hide Cartesian coordinate overlay. '''
+        """ Callback to display/hide Cartesian coordinate overlay. """
         self.tw.set_cartesian(True)
 
     def _do_polar_cb(self, button):
-        ''' Callback to display/hide Polar coordinate overlay. '''
+        """ Callback to display/hide Polar coordinate overlay. """
         self.tw.set_polar(True)
 
     def _do_rescale_cb(self, button):
-        ''' Callback to rescale coordinate space. '''
+        """ Callback to rescale coordinate space. """
         if self._gio_settings_overrides:
             return
         if self.tw.coord_scale == 1:
             self.tw.coord_scale = self.tw.height / 40
             self.tw.update_overlay_position()
             if self.tw.cartesian is True:
-                self.tw.overlay_shapes['Cartesian_labeled'].hide()
-                self.tw.overlay_shapes['Cartesian'].set_layer(OVERLAY_LAYER)
-            default_values['forward'] = [10]
-            default_values['back'] = [10]
-            default_values['arc'] = [90, 10]
-            default_values['setpensize'] = [1]
+                self.tw.overlay_shapes["Cartesian_labeled"].hide()
+                self.tw.overlay_shapes["Cartesian"].set_layer(OVERLAY_LAYER)
+            default_values["forward"] = [10]
+            default_values["back"] = [10]
+            default_values["arc"] = [90, 10]
+            default_values["setpensize"] = [1]
             self.tw.turtles.get_active_turtle().set_pen_size(1)
         else:
             self.tw.coord_scale = 1
             if self.tw.cartesian is True:
-                self.tw.overlay_shapes['Cartesian'].hide()
-                self.tw.overlay_shapes['Cartesian_labeled'].set_layer(
-                    OVERLAY_LAYER)
-            default_values['forward'] = [100]
-            default_values['back'] = [100]
-            default_values['arc'] = [90, 100]
-            default_values['setpensize'] = [5]
+                self.tw.overlay_shapes["Cartesian"].hide()
+                self.tw.overlay_shapes["Cartesian_labeled"].set_layer(OVERLAY_LAYER)
+            default_values["forward"] = [100]
+            default_values["back"] = [100]
+            default_values["arc"] = [90, 100]
+            default_values["setpensize"] = [5]
             self.tw.turtles.get_active_turtle().set_pen_size(5)
-        if hasattr(self, '_settings'):
-            self._settings.set_int(self._COORDINATE_SCALE,
-                                   int(self.tw.coord_scale))
+        if hasattr(self, "_settings"):
+            self._settings.set_int(self._COORDINATE_SCALE, int(self.tw.coord_scale))
 
         self.tw.recalculate_constants()
 
     def _do_toggle_hover_help_cb(self, button):
-        ''' Toggle hover help on/off '''
+        """ Toggle hover help on/off """
         self.tw.no_help = not button.get_active()
         if self.tw.no_help:
             self._do_hover_help_off_cb()
@@ -847,142 +860,134 @@ Would you like to save before quitting?'))
 
     def _do_toggle_plugin_cb(self, button):
         name = button.get_label()
-        if hasattr(self, '_settings'):
+        if hasattr(self, "_settings"):
             plugins_list = self._settings.get_string(self._PLUGINS_LIST)
-            plugins = plugins_list.split(',')
+            plugins = plugins_list.split(",")
             if button.get_active():
                 if name not in plugins:
                     plugins.append(name)
-                    self._settings.set_string(
-                        self._PLUGINS_LIST, ','.join(plugins))
-                label = _('Please restart %s in order to use the plugin.') \
-                    % self.name
+                    self._settings.set_string(self._PLUGINS_LIST, ",".join(plugins))
+                label = _("Please restart %s in order to use the plugin.") % self.name
             else:
                 if name in plugins:
                     plugins.remove(name)
-                    self._settings.set_string(
-                        self._PLUGINS_LIST, ','.join(plugins))
-                label = _('Please restart %s in order to unload the plugin.') \
-                    % self.name
-        self.tw.showlabel('status', label)
+                    self._settings.set_string(self._PLUGINS_LIST, ",".join(plugins))
+                label = (
+                    _("Please restart %s in order to unload the plugin.") % self.name
+                )
+        self.tw.showlabel("status", label)
 
     def _do_hover_help_on_cb(self):
-        ''' Turn hover help on '''
-        if hasattr(self, '_settings'):
+        """ Turn hover help on """
+        if hasattr(self, "_settings"):
             self._settings.set_int(self._HOVER_HELP, 0)
 
     def _do_hover_help_off_cb(self):
-        ''' Turn hover help off '''
+        """ Turn hover help off """
         self.tw.last_label = None
         if self.tw.status_spr is not None:
             self.tw.status_spr.hide()
-        if hasattr(self, '_settings'):
+        if hasattr(self, "_settings"):
             self._settings.set_int(self._HOVER_HELP, 1)
 
     def _do_palette_cb(self, widget):
-        ''' Callback to show/hide palette of blocks. '''
+        """ Callback to show/hide palette of blocks. """
         self.tw.show_palette(self.current_palette)
 
     def _do_hide_palette_cb(self, widget):
-        ''' Hide the palette of blocks. '''
+        """ Hide the palette of blocks. """
         self.tw.hide_palette()
 
     def _do_hideshow_cb(self, widget):
-        ''' Hide/show the blocks. '''
+        """ Hide/show the blocks. """
         self.tw.hideshow_button()
 
     def _do_eraser_cb(self, widget):
-        ''' Callback for eraser button. '''
+        """ Callback for eraser button. """
         self.tw.eraser_button()
         return
 
     def _do_run_cb(self, widget=None):
-        ''' Callback for run button (rabbit). '''
+        """ Callback for run button (rabbit). """
         self.tw.lc.trace = 0
         self.tw.hideblocks()
         self.tw.display_coordinates(clear=True)
-        self.tw.toolbar_shapes['stopiton'].set_layer(TAB_LAYER)
+        self.tw.toolbar_shapes["stopiton"].set_layer(TAB_LAYER)
         self.tw.run_button(0, running_from_button_push=True)
         return
 
     def _do_step_cb(self, widget):
-        ''' Callback for step button (turtle). '''
+        """ Callback for step button (turtle). """
         self.tw.lc.trace = 1
         self.tw.run_button(3, running_from_button_push=True)
         return
 
     def _do_trace_cb(self, widget):
-        ''' Callback for debug button (bug). '''
+        """ Callback for debug button (bug). """
         self.tw.lc.trace = 1
         self.tw.run_button(9, running_from_button_push=True)
         return
 
     def _do_stop_cb(self, widget):
-        ''' Callback for stop button. '''
+        """ Callback for stop button. """
         if self.tw.running_blocks:
-            self.tw.toolbar_shapes['stopiton'].hide()
+            self.tw.toolbar_shapes["stopiton"].hide()
         if self.tw.hide:
             self.tw.showblocks()
         self.tw.stop_button()
         self.tw.display_coordinates()
 
     def _do_save_macro_cb(self, widget):
-        ''' Callback for save stack button. '''
+        """ Callback for save stack button. """
         self.tw.copying_blocks = False
         self.tw.deleting_blocks = False
         if self.tw.saving_blocks:
-            self.win.get_window().set_cursor(
-                Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
+            self.win.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
             self.tw.saving_blocks = False
         else:
-            self.win.get_window().set_cursor(
-                Gdk.Cursor.new(Gdk.CursorType.HAND1))
+            self.win.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.HAND1))
             self.tw.saving_blocks = True
 
     def _do_delete_macro_cb(self, widget):
-        ''' Callback for delete stack button. '''
+        """ Callback for delete stack button. """
         self.tw.copying_blocks = False
         self.tw.saving_blocks = False
         if self.tw.deleting_blocks:
-            self.win.get_window().set_cursor(
-                Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
+            self.win.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
             self.tw.deleting_blocks = False
         else:
-            self.win.get_window().set_cursor(
-                Gdk.Cursor.new(Gdk.CursorType.HAND1))
+            self.win.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.HAND1))
             self.tw.deleting_blocks = True
 
     def _do_copy_cb(self, button):
-        ''' Callback for copy button. '''
+        """ Callback for copy button. """
         self.tw.saving_blocks = False
         self.tw.deleting_blocks = False
         if self.tw.copying_blocks:
-            self.win.get_window().set_cursor(
-                Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
+            self.win.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
             self.tw.copying_blocks = False
         else:
-            self.win.get_window().set_cursor(
-                Gdk.Cursor.new(Gdk.CursorType.HAND1))
+            self.win.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.HAND1))
             self.tw.copying_blocks = True
 
     def _do_paste_cb(self, button):
-        ''' Callback for paste button. '''
+        """ Callback for paste button. """
         self.tw.copying_blocks = False
         self.tw.saving_blocks = False
         self.tw.deleting_blocks = False
-        self.win.get_window().set_cursor(
-            Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
+        self.win.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
         clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
         text = clipboard.wait_for_text()
         if text is not None:
-            if self.tw.selected_blk is not None and \
-               self.tw.selected_blk.name == 'string' and \
-               text[0:2] != '[[':  # Don't paste block data into a string
+            if (
+                self.tw.selected_blk is not None
+                and self.tw.selected_blk.name == "string"
+                and text[0:2] != "[["
+            ):  # Don't paste block data into a string
                 self.tw.paste_text_in_block_label(text)
                 self.tw.selected_blk.resize()
             else:
-                self.tw.process_data(data_from_string(text),
-                                     self.tw.paste_offset)
+                self.tw.process_data(data_from_string(text), self.tw.paste_offset)
                 self.tw.paste_offset += PASTE_OFFSET
 
     def _do_about_cb(self, widget):
@@ -991,30 +996,28 @@ Would you like to save before quitting?'))
         about.set_version(self.version)
         about.set_comments(_(self.summary))
         about.set_website(self.website)
-        logo_path = os.path.join(self._share_path, 'activity',
-                                 self.icon_name + '.svg')
-        about.set_logo(
-            GdkPixbuf.Pixbuf.new_from_file(logo_path))
+        logo_path = os.path.join(self._share_path, "activity", self.icon_name + ".svg")
+        about.set_logo(GdkPixbuf.Pixbuf.new_from_file(logo_path))
         about.run()
         about.destroy()
 
     def _window_event(self, event, data):
-        ''' Callback for resize event. '''
-        data_file = open('.turtleartrc', 'w')
-        data_file.write(str(data.x) + '\n')
-        data_file.write(str(data.y) + '\n')
-        data_file.write(str(data.width) + '\n')
-        data_file.write(str(data.height) + '\n')
+        """ Callback for resize event. """
+        data_file = open(".turtleartrc", "w")
+        data_file.write(str(data.x) + "\n")
+        data_file.write(str(data.y) + "\n")
+        data_file.write(str(data.width) + "\n")
+        data_file.write(str(data.height) + "\n")
 
     def nick_changed(self, nick):
-        ''' TODO: Rename default turtle in dictionary '''
+        """ TODO: Rename default turtle in dictionary """
         pass
 
     def color_changed(self, colors):
-        ''' Reskin turtle with collaboration colors '''
+        """ Reskin turtle with collaboration colors """
         turtle = self.tw.turtles.get_turtle(self.tw._default_turtle_name)
         try:
-            turtle.colors = colors.split(',')
+            turtle.colors = colors.split(",")
         except BaseException:
             turtle.colors = DEFAULT_TURTLE_COLORS
         turtle.custom_shapes = True  # Force regeneration of shapes
@@ -1022,23 +1025,22 @@ Would you like to save before quitting?'))
         turtle.show()
 
     def _get_execution_dir(self):
-        ''' From whence is the program being executed? '''
+        """ From whence is the program being executed? """
         dirname = os.path.dirname(__file__)
-        if dirname == '':
-            if os.path.exists(os.path.join('~', 'Activities',
-                                           'TurtleArt.activity')):
-                return os.path.join('~', 'Activities', 'TurtleArt.activity')
+        if dirname == "":
+            if os.path.exists(os.path.join("~", "Activities", "TurtleArt.activity")):
+                return os.path.join("~", "Activities", "TurtleArt.activity")
             elif os.path.exists(self._INSTALL_PATH):
                 return self._INSTALL_PATH
             elif os.path.exists(self._ALTERNATIVE_INSTALL_PATH):
                 return self._ALTERNATIVE_INSTALL_PATH
             else:
-                return os.path.abspath('.')
+                return os.path.abspath(".")
         else:
             return os.path.abspath(dirname)
 
     def restore_state(self):
-        ''' Anything that needs restoring after a clear screen can go here '''
+        """ Anything that needs restoring after a clear screen can go here """
         pass
 
     def hide_store(self, widget=None):
@@ -1049,8 +1051,9 @@ Would you like to save before quitting?'))
         if self._sample_window is None:
             self._sample_box = Gtk.EventBox()
             self._sample_window = Gtk.ScrolledWindow()
-            self._sample_window.set_policy(Gtk.PolicyType.AUTOMATIC,
-                                           Gtk.PolicyType.AUTOMATIC)
+            self._sample_window.set_policy(
+                Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC
+            )
             width = Gdk.Screen.width() / 2
             height = Gdk.Screen.height() / 2
             self._sample_window.set_size_request(width, height)
@@ -1061,8 +1064,7 @@ Would you like to save before quitting?'))
             icon_view = Gtk.IconView()
             icon_view.set_model(store)
             icon_view.set_selection_mode(Gtk.SelectionMode.SINGLE)
-            icon_view.connect('selection-changed', self._sample_selected,
-                              store)
+            icon_view.connect("selection-changed", self._sample_selected, store)
             icon_view.set_pixbuf_column(0)
             icon_view.grab_focus()
             self._sample_window.add_with_viewport(icon_view)
@@ -1108,27 +1110,24 @@ Would you like to save before quitting?'))
     def _sample_loader(self):
         # Convert from thumbnail path to sample path
         basename = os.path.basename(self._selected_sample)[:-4]
-        for suffix in ['.ta', '.tb']:
-            file_path = os.path.join(self._share_path,
-                                     'samples', basename + suffix)
+        for suffix in [".ta", ".tb"]:
+            file_path = os.path.join(self._share_path, "samples", basename + suffix)
             if os.path.exists(file_path):
                 self.tw.load_files(file_path)
                 break
-        self.win.get_window().set_cursor(
-            Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
+        self.win.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR))
 
     def _fill_samples_list(self, store):
-        '''
+        """
         Append images from the artwork_paths to the store.
-        '''
+        """
         for filepath in self._scan_for_samples():
             pixbuf = None
-            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(
-                filepath, 100, 100)
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(filepath, 100, 100)
             store.append([pixbuf, filepath])
 
     def _scan_for_samples(self):
-        path = os.path.join(self._share_path, 'samples', 'thumbnails')
+        path = os.path.join(self._share_path, "samples", "thumbnails")
         samples = []
         for name in os.listdir(path):
             if name.endswith(".png"):

--- a/TurtleArt/turtleblocks.py
+++ b/TurtleArt/turtleblocks.py
@@ -206,6 +206,8 @@ return %s(self)" % (p, P, P)
                 self._gnome_plugins.append(list(plugin.values())[0](self))
             except ImportError as e:
                 print('failed to import %s: %s' % (P, str(e)))
+            except ValueError as e:
+                print('failed to import %s: %s' % (P, str(e)))
 
     def _run_gnome_plugins(self):
         ''' Tell the plugin about the TurtleWindow instance. '''


### PR DESCRIPTION
While exploring https://github.com/sugarlabs/turtleart-activity/issues/84 from an F34 machine that does not have Sugar installed, I bumped up against a few seemingly unnecessary dependencies, which I bypass with exception handlers.

A second commit applied "black" to reformat the files I changed.
