### PR TITLE
Fix the build error from the wrong option to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ if len(sys.argv) > 1 and '--no-sugar' == sys.argv[1]:
           version='0.9.4',
           packages=['TurtleArt', 'TurtleArt.util'],
           scripts=['turtleblocks'],
-          package_data=DATA_FILES,
+          data_files=DATA_FILES,
           cmdclass={"install": post_install}
           )
 else:


### PR DESCRIPTION
The turtleart-activity builds failed with the error:

error in Turtle Art setup command: 'package_data' must be a dictionary mapping package names to lists of string wildcard patterns
Error: module turtleblocks: Child process exited with code 1

According to Python 3.9's Writing the Setup Script document - Installing Additional Files [1], setup()'s option "package_data" should be replaced as "data_files" for setuptools.

[1] https://docs.python.org/3.9/distutils/setupscript.html#installing-additional-files

Fixes: 1000384f975b ("Replace deprecated distutils with setuptools")