### PR TITLE
Prevent Gtk-CRITICAL warning when removing toolbar item

### DIFF
--- a/TurtleArtActivity.py
+++ b/TurtleArtActivity.py
@@ -222,7 +222,8 @@ class TurtleArtActivity(activity.Activity):
             self.toolbox.toolbar.remove(self.samples_button)
             self.toolbox.toolbar.remove(self.stop_separator)
         self.toolbox.toolbar.remove(self.stop_button)
-        self._view_toolbar.remove(self._coordinates_toolitem)
+        if self._coordinates_toolitem in self._view_toolbar:
+            self._view_toolbar.remove(self._coordinates_toolitem)
 
         if Gdk.Screen.width() / 14 < style.GRID_CELL_SIZE:
             self.samples_button2.show()


### PR DESCRIPTION
Issue: When windows size gets decreased to a specific point and then increase again the following warning occurs, `Gtk-CRITICAL **: 13:29:23.501: gtk_toolbar_remove: assertion 'content_to_remove != NULL' failed`

Change: Added a safety check to ensure that `self._coordinates_toolitem` is in  `self._view_toolbar` before attempting to remove it.