### PR TITLE
Fix help popup message position

### DIFF
--- a/TurtleArt/tawindow.py
+++ b/TurtleArt/tawindow.py
@@ -4539,7 +4539,7 @@ class TurtleArtWindow():
                     else:
                         offset_from_bottom *= 2
                 self.status_spr.move(
-                    (0,
+                    (self.activity.sw.get_hadjustment().get_value(),
                      self.height - offset_from_bottom + self.activity.sw.get_vadjustment().get_value()))
             elif self.interactive_mode:
                 self.status_spr.move(


### PR DESCRIPTION
Issue:
When horizontally scrolling, a part of the popup help messages would be created in the non-visible part of the screen.

Solution:
Change the x value in `self.activity.sw.get_vadjustment().get_value()`, to be the horizontal adjustment of the screen.

Fixes #75

@chimosky @sourabhaa, kindly review