### PR TITLE
Hollow Line Block Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,17 @@ Copied Dependencies
 * CollabWrapper,
 * sugariconify,
 
+Changes Made To Add Hollow Line Block
+-------------------
+
+* taturtle:
+Enhanced the forward, backward, arc, and setxy functions to support dual-mode operation via a wrapper. One mode retains the standard behavior, while the other introduces "hollow draw" functionality.
+
+* tabasics:
+Added the logic for the "Draw Hollow" button, and modified the behavior of forward, backward, arc, and setxy to handle hollow draw mode when enabled.
+
+* talogo:
+Introduced support for hollow drawing in forward. Added logic to manage custom attributes, including thickness and a boolean flag indicating whether hollow drawing is active. Drawing behavior is now conditionally executed based on this flag.
+
+* tawindo:
+Added a function to return self.lc, enabling external access to the talogo instance.

--- a/TurtleArt/tabasics.py
+++ b/TurtleArt/tabasics.py
@@ -166,11 +166,28 @@ class Palettes():
                           default=100,
                           logo_command='forward',
                           help_string=_('moves turtle forward'))
+
         self.tw.lc.def_prim(
             'forward', 1,
-            Primitive(Turtle.forward,
+            Primitive(Turtle.forward_wrapper,  #Added a wrapper just like ro backward, setxy and arc
                       arg_descs=[ArgSlot(TYPE_NUMBER)],
                       call_afterwards=self.after_move))
+
+        palette.add_block("hollow_draw",
+                          style='clamp-style-1arg',
+                          label=_('hollow line'),
+                          prim_name='hollow_line',
+                          default=[30, None],
+                          # logo_command='forward_hollow',
+                          help_string=_(
+                              'draws the block inside with a thickness equal to what it is specified, default 30')
+                          )
+
+        self.tw.lc.def_prim(
+            'hollow_line', 2,
+            Primitive(self.tw.lc.hollow_line,
+                      arg_descs=[ArgSlot(TYPE_NUMBER), ArgSlot(TYPE_OBJECT, call_arg=False)]),
+            rprim=True)
 
         palette.add_block('back',
                           style='basic-style-1arg',
@@ -181,7 +198,7 @@ class Palettes():
                           help_string=_('moves turtle backward'))
         self.tw.lc.def_prim(
             'back', 1,
-            Primitive(Turtle.backward,
+            Primitive(Turtle.backward_wrapper,
                       arg_descs=[ArgSlot(TYPE_NUMBER)],
                       call_afterwards=self.after_move))
 
@@ -239,11 +256,12 @@ degrees)'))
                           label=[_('arc'), _('angle'), _('radius')],
                           prim_name='arc',
                           default=[90, 100],
-                          logo_command='taarc',
+                          logo_command='arc',
                           help_string=_('moves turtle along an arc'))
+
         self.tw.lc.def_prim(
             'arc', 2,
-            Primitive(Turtle.arc,
+            Primitive(Turtle.arc_wrapper,
                       arg_descs=[ArgSlot(TYPE_NUMBER),
                                  ArgSlot(TYPE_NUMBER)],
                       call_afterwards=self.after_arc))
@@ -258,9 +276,10 @@ degrees)'))
                           default=[0, 0],
                           help_string=_('moves turtle to position xcor, ycor; \
 (0, 0) is in the center of the screen.'))
+
         self.tw.lc.def_prim(
             'setxy2', 2,
-            Primitive(Turtle.set_xy,
+            Primitive(Turtle.set_xy_wrapper,
                       arg_descs=[ArgSlot(TYPE_NUMBER), ArgSlot(TYPE_NUMBER)],
                       call_afterwards=self.after_move))
         define_logo_function('tasetxy', 'to tasetxy :x :y\nsetxy :x :y\nend\n')
@@ -328,6 +347,7 @@ turtle (can be used in place of a number block)'),
                           label=['turtle'])
 
         # Deprecated
+
         palette.add_block('setxy',
                           hidden=True,
                           style='basic-style-2arg',

--- a/TurtleArt/tablock.py
+++ b/TurtleArt/tablock.py
@@ -86,9 +86,9 @@ class Blocks:
 
     def get_block(self, i):
         if i < 0 or i > len(self.list) - 1:
-            return(None)
+            return (None)
         else:
-            return(self.list[i])
+            return (self.list[i])
 
     def swap(self, blk1, blk2):
         i1 = self.list.index(blk1)
@@ -97,7 +97,7 @@ class Blocks:
         self.list[i2] = blk1
 
     def length_of_list(self):
-        return(len(self.list))
+        return (len(self.list))
 
     def append_to_list(self, block):
         self.list.append(block)
@@ -595,7 +595,7 @@ class Block:
 
     def get_expand_x_y(self):
         if self.spr is None:
-            return(0, 0)
+            return (0, 0)
         return (self.ex, self.ey, self.ey2)
 
     def _new_block_from_factory(self, sprite_list, x, y, copy_block=None):

--- a/TurtleArt/tacanvas.py
+++ b/TurtleArt/tacanvas.py
@@ -198,6 +198,7 @@ class TurtleGraphics:
         _larc(self.canvas, x, y, r, a, heading)
         self.inval()
         if self.cr_svg is not None:
+
             _larc(self.cr_svg, x, y, r, a, heading)
 
     def set_pen_size(self, pen_size):
@@ -415,7 +416,7 @@ class TurtleGraphics:
             w = self.turtle_window.turtle_canvas.get_width()
             h = self.turtle_window.turtle_canvas.get_height()
             if x < 0 or x > (w - 1) or y < 0 or y > (h - 1):
-                return(-1, -1, -1, -1)
+                return (-1, -1, -1, -1)
             # create a new 1x1 cairo surface
             cs = cairo.ImageSurface(cairo.FORMAT_RGB24, 1, 1)
             cr = cairo.Context(cs)
@@ -427,7 +428,7 @@ class TurtleGraphics:
             pixels = cs.get_data()  # Read the pixel
             return (pixels[2], pixels[1], pixels[0], 0)
         else:
-            return(-1, -1, -1, -1)
+            return (-1, -1, -1, -1)
 
     def svg_close(self):
         ''' Close current SVG graphic '''

--- a/TurtleArt/taexportlogo.py
+++ b/TurtleArt/taexportlogo.py
@@ -99,7 +99,8 @@ def save_logo(tw):
                 stack_count += 1
             if logo_command in dispatch_table:
                 if i + 1 < len(psuedocode):
-                    this_stack += dispatch_table[logo_command](psuedocode[i + 1])
+                    this_stack += dispatch_table[logo_command](
+                        psuedocode[i + 1])
                     skip = True
                 else:
                     print("missing arg to %s" % (logo_command))

--- a/TurtleArt/tasprite_factory.py
+++ b/TurtleArt/tasprite_factory.py
@@ -314,7 +314,8 @@ class SVG:
         self.reset_min_max()
         svg = self._start_boolean(self._stroke_width / 2.0,
                                   self._radius * 5.5 + self._stroke_width / 2.0 + self._innie_y2 + self._innie_spacer + self._expand_y)
-        svg += self._rline_to(0, -self._radius * 3.5 - self._innie_y2 - self._innie_spacer - self._stroke_width)
+        svg += self._rline_to(0, -self._radius * 3.5 -
+                              self._innie_y2 - self._innie_spacer - self._stroke_width)
 
         self._hide_x = self._x + self._radius + self._stroke_width
         self._hide_y = self._y

--- a/TurtleArt/taturtle.py
+++ b/TurtleArt/taturtle.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2010-13 Walter Bender
-
+import math
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
@@ -34,7 +34,7 @@ from .tacanvas import wrap100, COLOR_TABLE
 from .sprites import Sprite
 from .tautils import (debug_output, data_to_string, round_int, get_path,
                       image_to_base64)
-from TurtleArt.talogo import logoerror
+from TurtleArt.talogo import logoerror, LogoCode
 
 SHAPES = 36
 DEGTOR = pi / 180.
@@ -65,6 +65,9 @@ class Turtles:
         self._active_turtle = None
         self._default_turtle_name = DEFAULT_TURTLE
 
+        #to be used in taturtle
+        self.lc = turtle_window
+
     def get_turtle(self, turtle_name, append=False, colors=None):
         ''' Find a turtle '''
         if turtle_name in self.dict:
@@ -89,7 +92,7 @@ class Turtles:
 
     def turtle_count(self):
         ''' How many turtles are there? '''
-        return(len(self.dict))
+        return (len(self.dict))
 
     def add_to_dict(self, turtle_name, turtle):
         ''' Add a new turtle '''
@@ -98,7 +101,7 @@ class Turtles:
     def remove_from_dict(self, turtle_name):
         ''' Delete a turtle '''
         if turtle_name in self.dict:
-            del(self.dict[turtle_name])
+            del (self.dict[turtle_name])
 
     def show_all(self):
         ''' Make all turtles visible '''
@@ -117,7 +120,7 @@ class Turtles:
         if self._default_pixbufs == []:
             self._default_pixbufs = generate_turtle_pixbufs(
                 ["#008000", "#00A000"])
-        return(self._default_pixbufs)
+        return (self._default_pixbufs)
 
     def turtle_to_screen_coordinates(self, pos):
         ''' The origin of turtle coordinates is the center of the screen '''
@@ -143,21 +146,21 @@ class Turtles:
         if turtle_name not in self.dict:
             debug_output('%s not found in turtle dictionary' % (turtle_name),
                          self.turtle_window.running_sugar)
-            raise logoerror("#syntaxerror")
+            # raise logoerror("#syntaxerror")
         return self.dict[turtle_name].get_x()
 
     def get_turtle_y(self, turtle_name):
         if turtle_name not in self.dict:
             debug_output('%s not found in turtle dictionary' % (turtle_name),
                          self.turtle_window.running_sugar)
-            raise logoerror("#syntaxerror")
+            # raise logoerror("#syntaxerror")
         return self.dict[turtle_name].get_y()
 
     def get_turtle_heading(self, turtle_name):
         if turtle_name not in self.dict:
             debug_output('%s not found in turtle dictionary' % (turtle_name),
                          self.turtle_window.running_sugar)
-            raise logoerror("#syntaxerror")
+            # raise logoerror("#syntaxerror")
         return self.dict[turtle_name].get_heading()
 
     def set_turtle(self, turtle_name, colors=None):
@@ -224,7 +227,6 @@ class Turtle:
         self._pen_state = True
         self._pen_fill = False
         self._poly_points = []
-
         self._prep_shapes(turtle_name, self._turtles, turtle_colors)
 
         # Create a sprite for the turtle in interactive mode.
@@ -551,37 +553,98 @@ class Turtle:
         self.right(degrees, share)
 
     def _draw_line(self, old, new, pendown):
+
         if self._pen_state and pendown:
             self._turtles.turtle_window.canvas.set_source_rgb()
             pos1 = self._turtles.turtle_to_screen_coordinates(old)
             pos2 = self._turtles.turtle_to_screen_coordinates(new)
+
             self._turtles.turtle_window.canvas.draw_line(pos1[0], pos1[1],
                                                          pos2[0], pos2[1])
+
             if self._pen_fill:
                 if self._poly_points == []:
                     self._poly_points.append(('move', pos1[0], pos1[1]))
                 self._poly_points.append(('line', pos2[0], pos2[1]))
 
-    def forward(self, distance, share=True):
+    def forward(self, distance, share=True, thickness=None):
         scaled_distance = distance * self._turtles.turtle_window.coord_scale
 
         old = self.get_xy()
         xcor = old[0] + scaled_distance * sin(self._heading * DEGTOR)
         ycor = old[1] + scaled_distance * cos(self._heading * DEGTOR)
 
-        self._draw_line(old, (xcor, ycor), True)
-        self.move_turtle((xcor, ycor))
+        if thickness is None:
+            self._draw_line(old, (xcor, ycor), True)
+            self.move_turtle((xcor, ycor))
+        else:
+            if self._pen_state:
+                # Need this to make the circle work at the first iteration
+                self._turtles.turtle_window.canvas.set_source_rgb()
+
+            # Draw first circle
+            # distance>=0 means that we are not going backward
+            self.larc(180, self._turtles.lc.LC().ht(), True, distance >= 0)
+
+            # Draw right
+            new_pos = [None, None]
+            new_pos[0] = xcor + thickness * cos(self._heading * DEGTOR)
+            new_pos[1] = ycor + thickness * -sin(self._heading * DEGTOR)
+
+            old_pos = [None, None]
+            old_pos[0] = old[0] + thickness * cos(self._heading * DEGTOR)
+            old_pos[1] = old[1] + thickness * -sin(self._heading * DEGTOR)
+
+            self._draw_line(old_pos, new_pos, True)
+
+            # Draw Left
+            new_pos = [None, None]
+            new_pos[0] = xcor - thickness * cos(self._heading * DEGTOR)
+            new_pos[1] = ycor - thickness * -sin(self._heading * DEGTOR)
+
+            old_pos = [None, None]
+            old_pos[0] = old[0] - thickness * cos(self._heading * DEGTOR)
+            old_pos[1] = old[1] - thickness * -sin(self._heading * DEGTOR)
+
+            self._draw_line(old_pos, new_pos, True)
+
+            self.move_turtle((xcor, ycor))
+            # Draw second circle
+            self.larc(180, self._turtles.lc.LC().ht(), True, distance >= 0)
 
         if self._turtles.turtle_window.sharing() and share:
             event = data_to_string([self._turtles.turtle_window.nick,
                                     int(distance)])
             self._turtles.turtle_window.send_event('f', event)
 
+    # This piece becomes obsolete since the backward button uses backward_wrapper which uses forward_wrapper
     def backward(self, distance, share=True):
         distance = 0 - distance
         self.forward(distance, share)
 
-    def set_xy(self, x=None, y=None, share=True, pendown=True, dragging=False):
+    def forward_wrapper(self, distance):
+        if self._turtles.lc.LC().hm():
+            self.forward(distance, True, self._turtles.lc.LC().ht())
+        else:
+            self.forward(distance)
+
+    def backward_wrapper(self, distance):
+        distance = 0 - distance
+        self.forward_wrapper(distance)
+
+    def arc_wrapper(self, a, r):
+        if self._turtles.lc.LC().hm():
+            self.arc(a, r, True, self._turtles.lc.LC().ht())
+        else:
+            self.arc(a, r)
+
+    def set_xy_wrapper(self, x, y):
+        if self._turtles.lc.LC().hm():  # it is not advice to use set xy in a hollow block, since it can give unexpected results
+            self.set_xy(x, y, True, True, False, self._turtles.lc.LC().ht())
+        else:
+            self.set_xy(x, y)
+
+    def set_xy(self, x=None, y=None, share=True, pendown=True, dragging=False, thickness=None):
         old = self.get_xy()
         if x is None or y is None:
             x = old[0]
@@ -593,24 +656,139 @@ class Turtle:
             xcor = x * self._turtles.turtle_window.coord_scale
             ycor = y * self._turtles.turtle_window.coord_scale
 
-        self._draw_line(old, (xcor, ycor), pendown)
-        self.move_turtle((xcor, ycor))
+        if thickness is None:
+            self._draw_line(old, (xcor, ycor), pendown)
+            self.move_turtle((xcor, ycor))
+        else:
+            # Draw first circle
+            if self._pen_state:
+                self._turtles.turtle_window.canvas.set_source_rgb()
+            self.larc(180, self._turtles.lc.LC().ht(), True, True)
+
+            # Move right
+            new_pos = [None, None]
+            new_pos[0] = xcor + thickness * cos(self._heading * DEGTOR)
+            new_pos[1] = ycor + thickness * -sin(self._heading * DEGTOR)
+
+            old_pos = [None, None]
+            old_pos[0] = old[0] + thickness * cos(self._heading * DEGTOR)
+            old_pos[1] = old[1] + thickness * -sin(self._heading * DEGTOR)
+
+            self._draw_line(old_pos, new_pos, True)
+
+            # Move Left
+            new_pos = [None, None]
+            new_pos[0] = xcor - thickness * cos(self._heading * DEGTOR)
+            new_pos[1] = ycor - thickness * -sin(self._heading * DEGTOR)
+
+            old_pos = [None, None]
+            old_pos[0] = old[0] - thickness * cos(self._heading * DEGTOR)
+            old_pos[1] = old[1] - thickness * -sin(self._heading * DEGTOR)
+
+            self._draw_line(old_pos, new_pos, True)
+
+            self.move_turtle((xcor, ycor))
+
+            # Draw second circle
+            self.larc(180, self._turtles.lc.LC().ht(), True, True)
 
         if self._turtles.turtle_window.sharing() and share:
             event = data_to_string([self._turtles.turtle_window.nick,
                                     [round_int(xcor), round_int(ycor)]])
             self._turtles.turtle_window.send_event('x', event)
 
-    def arc(self, a, r, share=True):
+    def arc(self, a, r, share=True, thickness=None):
         ''' Draw an arc '''
         if self._pen_state:
             self._turtles.turtle_window.canvas.set_source_rgb()
-        if a < 0:
-            pos = self.larc(-a, r)
-        else:
-            pos = self.rarc(a, r)
 
-        self.move_turtle(pos)
+        if thickness is None:
+            if a < 0:
+                pos = self.larc(-a, r)
+            else:
+                pos = self.rarc(a, r)
+            self.move_turtle(pos)
+        else:  # Draw hollow
+            self.larc(180, thickness, True, True)
+            self._heading += 180  # To handle turtle alignment
+
+            prev_rotation = self._heading  # It will get changed by moving
+            prev_pos = self.get_xy()  # It will get changed
+
+            if a < 0:
+                # Move right
+
+                new_pos = [None, None]
+                new_pos[0] = prev_pos[0] - thickness * \
+                    cos(self._heading * DEGTOR)
+                new_pos[1] = prev_pos[1] - thickness * - \
+                    sin(self._heading * DEGTOR)
+                self.move_turtle(new_pos)
+
+                self.larc(-a, r - thickness)
+
+                # Restore for next transformation
+
+                self._heading = prev_rotation
+                self.move_turtle(prev_pos)
+
+                # Move left
+                new_pos = [None, None]
+                new_pos[0] = prev_pos[0] + thickness * \
+                    cos(self._heading * DEGTOR)
+                new_pos[1] = prev_pos[1] + thickness * - \
+                    sin(self._heading * DEGTOR)
+                self.move_turtle(new_pos)
+                self.larc(-a, r + thickness)
+
+                # Restore for last transformation
+                self._heading = prev_rotation
+                self.move_turtle(prev_pos)
+            else:
+                # Move right
+
+                new_pos = [None, None]
+                new_pos[0] = prev_pos[0] + thickness * \
+                    cos(self._heading * DEGTOR)
+                new_pos[1] = prev_pos[1] + thickness * - \
+                    sin(self._heading * DEGTOR)
+                self.move_turtle(new_pos)
+
+                self.rarc(a, r - thickness)
+
+                # Restore for next transformation
+
+                self._heading = prev_rotation
+                self.move_turtle(prev_pos)
+
+                # Move left
+                new_pos = [None, None]
+                new_pos[0] = prev_pos[0] - thickness * \
+                    cos(self._heading * DEGTOR)
+                new_pos[1] = prev_pos[1] - thickness * - \
+                    sin(self._heading * DEGTOR)
+                self.move_turtle(new_pos)
+                self.rarc(a, r + thickness)
+
+                # Restore for last transformation
+                self._heading = prev_rotation
+                self.move_turtle(prev_pos)
+
+            # move turtle to central position without drawing
+            prev = self._pen_state
+            self._pen_state = False
+
+            if a < 0:
+                pos = self.larc(-a, r)
+            else:
+                pos = self.rarc(a, r)
+
+            self._pen_state = prev  # Restore original state
+
+            self.move_turtle(pos)
+
+            self._heading += 180  # To handle turtle alignment
+            self.larc(180, thickness, True, True)
 
         if self._turtles.turtle_window.sharing() and share:
             event = data_to_string([self._turtles.turtle_window.nick,
@@ -624,14 +802,18 @@ class Turtle:
             r = -r
             a = -a
         pos = self.get_xy()
+
         cx = pos[0] + r * cos(self._heading * DEGTOR)
         cy = pos[1] - r * sin(self._heading * DEGTOR)
+
         if self._pen_state:
             npos = self._turtles.turtle_to_screen_coordinates((cx, cy))
+
             self._turtles.turtle_window.canvas.rarc(npos[0], npos[1], r, a,
                                                     self._heading)
 
             if self._pen_fill:
+
                 self._poly_points.append(('move', npos[0], npos[1]))
                 self._poly_points.append(('rarc', npos[0], npos[1], r,
                                           (self._heading - 180) * DEGTOR,
@@ -641,19 +823,28 @@ class Turtle:
         return [cx - r * cos(self._heading * DEGTOR),
                 cy + r * sin(self._heading * DEGTOR)]
 
-    def larc(self, a, r):
+    def larc(self, a, r, helper=False, forward=False):
         ''' draw a counter-clockwise arc '''
         r *= self._turtles.turtle_window.coord_scale
         if r < 0:
             r = -r
             a = -a
         pos = self.get_xy()
-        cx = pos[0] - r * cos(self._heading * DEGTOR)
-        cy = pos[1] + r * sin(self._heading * DEGTOR)
+
+        if helper is False:
+            cx = pos[0] - r * cos(self._heading * DEGTOR)
+            cy = pos[1] + r * sin(self._heading * DEGTOR)
+        else:
+            cx = pos[0]
+            cy = pos[1]
+
         if self._pen_state:
             npos = self._turtles.turtle_to_screen_coordinates((cx, cy))
+            # Turn the turtle 180 to make the circle point
+            # Outward only if I'm moving forward and using this function as a helper
             self._turtles.turtle_window.canvas.larc(npos[0], npos[1], r, a,
-                                                    self._heading)
+                                                    self._heading - (180 * helper * forward))
+
 
             if self._pen_fill:
                 self._poly_points.append(('move', npos[0], npos[1]))
@@ -662,8 +853,9 @@ class Turtle:
                                           (self._heading - a) * DEGTOR))
 
         self.right(-a, False)
-        return [cx + r * cos(self._heading * DEGTOR),
-                cy - r * sin(self._heading * DEGTOR)]
+        if helper is False:
+            return [cx + r * cos(self._heading * DEGTOR),
+                    cy - r * sin(self._heading * DEGTOR)]
 
     def draw_pixbuf(self, pixbuf, a, b, x, y, w, h, path, share=True):
         ''' Draw a pixbuf '''

--- a/TurtleArt/tautils.py
+++ b/TurtleArt/tautils.py
@@ -456,11 +456,11 @@ def get_pixbuf_from_journal(dsobject, w, h):
 def get_path(activity, subpath):
     ''' Find a Rainbow-approved place for temporary files. '''
     if hasattr(activity, "get_activity_root"):
-        return(os.path.join(activity.get_activity_root(), subpath))
+        return (os.path.join(activity.get_activity_root(), subpath))
     else:
         # Early versions of Sugar didn't support get_activity_root()
-        return(os.path.join(os.environ['HOME'], '.sugar/default',
-                            'org.laptop.TurtleArtActivity', subpath))
+        return (os.path.join(os.environ['HOME'], '.sugar/default',
+                             'org.laptop.TurtleArtActivity', subpath))
 
 
 def image_to_base64(image_path, tmp_path):
@@ -836,7 +836,7 @@ def get_stack_width_and_height(blk):
             maxx = x + w
         if y + h > maxy:
             maxy = y + h
-    return(maxx - minx, maxy - miny)
+    return (maxx - minx, maxy - miny)
 
 
 def get_stack_name(blk):

--- a/TurtleArt/tawindow.py
+++ b/TurtleArt/tawindow.py
@@ -364,6 +364,10 @@ class TurtleArtWindow():
             self._init_plugins()
             self._setup_plugins()
 
+    #To return lc for it to be used in taturtle
+    def LC(self):
+        return self.lc
+
     def get_global_objects(self):
         return global_objects
 
@@ -440,7 +444,8 @@ class TurtleArtWindow():
         plist = sorted(turtleart_plugin_list.keys())
         plugin_saved = []
         if hasattr(self.activity, '_settings'):
-            plugin_saved = self.activity._settings.get_string(self.activity._PLUGINS_LIST)
+            plugin_saved = self.activity._settings.get_string(
+                self.activity._PLUGINS_LIST)
 
         for plugin_dir in plist:
             plugin_path = turtleart_plugin_list[plugin_dir]
@@ -4554,7 +4559,7 @@ class TurtleArtWindow():
         h *= (self.canvas.height - y)
         dx *= w
         dy *= h
-        return(w, h, x, y, dx, dy)
+        return (w, h, x, y, dx, dy)
 
     def save_for_upload(self, file_name):
         ''' Grab the current canvas and save it for upload '''
@@ -4848,7 +4853,7 @@ class TurtleArtWindow():
                 maxx = x + w
             if y + h > maxy:
                 maxy = y + h
-        return(maxx - minx, maxy - miny)
+        return (maxx - minx, maxy - miny)
 
     # Utilities related to putting a image 'skin' on a block
 

--- a/TurtleArt/textchannelwrapper.py
+++ b/TurtleArt/textchannelwrapper.py
@@ -822,7 +822,7 @@ class _TextChannelWrapper(object):
         if my_csh == cs_handle:
             handle = conn.GetSelfHandle()
         elif group.GetGroupFlags() & \
-              CHANNEL_GROUP_FLAG_CHANNEL_SPECIFIC_HANDLES:
+                CHANNEL_GROUP_FLAG_CHANNEL_SPECIFIC_HANDLES:
             handle = group.GetHandleOwners([cs_handle])[0]
         else:
             handle = cs_handle

--- a/TurtleArt/turtleblocks.py
+++ b/TurtleArt/turtleblocks.py
@@ -186,7 +186,8 @@ class TurtleMain:
             schemas_path = activity_root
 
         # create a local Gio.Settings based on the compiled schema
-        source = Gio.SettingsSchemaSource.new_from_directory(schemas_path, None, True)
+        source = Gio.SettingsSchemaSource.new_from_directory(
+            schemas_path, None, True)
         schema = source.lookup(self._GIO_SETTINGS, True)
         _settings = Gio.Settings.new_full(schema, None, None)
         return _settings
@@ -199,7 +200,8 @@ class TurtleMain:
 
     def _get_gnome_plugin_home(self):
         """ Use plugin directory associated with execution path. """
-        if os.path.exists(os.path.join(self._lib_path, self._GNOME_PLUGIN_SUBPATH)):
+        if os.path.exists(os.path.join(self._lib_path,
+                          self._GNOME_PLUGIN_SUBPATH)):
             return os.path.join(self._lib_path, self._GNOME_PLUGIN_SUBPATH)
         else:
             return None
@@ -352,7 +354,8 @@ return %s(self)"
     def _parse_command_line(self):
         """ Try to make sense of the command-line arguments. """
         try:
-            opts, args = getopt.getopt(argv[1:], "hor", ["help", "output_png", "run"])
+            opts, args = getopt.getopt(
+                argv[1:], "hor", ["help", "output_png", "run"])
         except getopt.GetoptError as err:
             print(str(err))
             print(self._HELP_MSG)
@@ -381,7 +384,8 @@ return %s(self)"
             if not os.path.exists(self._ta_file):
                 self._ta_file = os.path.join(self._abspath, self._ta_file)
                 if not os.path.exists(self._ta_file):
-                    assert False, "%s: %s" % (self._ta_file, _("File not found"))
+                    assert False, "%s: %s" % (
+                        self._ta_file, _("File not found"))
 
     def _ensure_sugar_paths(self):
         """ Make sure Sugar paths are present. """
@@ -404,7 +408,8 @@ return %s(self)"
             # We'll assume it needs to be created
             try:
                 self._mkdir_p(CONFIG_HOME)
-                data_file = open(os.path.join(CONFIG_HOME, "turtleartrc"), "a+")
+                data_file = open(os.path.join(
+                    CONFIG_HOME, "turtleartrc"), "a+")
             except IOError as e:
                 # We can't write to the configuration file, use
                 # a faux file that will persist for the length of
@@ -453,7 +458,8 @@ return %s(self)"
         win.maximize()
         win.set_title("%s %s" % (self.name, str(self.version)))
         if os.path.exists(os.path.join(self._share_path, self._ICON_SUBPATH)):
-            win.set_icon_from_file(os.path.join(self._share_path, self._ICON_SUBPATH))
+            win.set_icon_from_file(os.path.join(
+                self._share_path, self._ICON_SUBPATH))
         win.show()
         win.connect("delete_event", self._quit_ta)
 
@@ -723,7 +729,8 @@ Would you like to save before quitting?"
         temp_save_folder = self.tw.save_folder
         self.tw.load_save_folder = self._autosavedirname
         self.tw.save_folder = self._autosavedirname
-        self.tw.save_file(file_name=os.path.join(self._autosavedirname, "autosave.tb"))
+        self.tw.save_file(file_name=os.path.join(
+            self._autosavedirname, "autosave.tb"))
         self.tw.save_folder = temp_save_folder
         self.tw.load_save_folder = temp_load_save_folder
 
@@ -839,14 +846,16 @@ Would you like to save before quitting?"
             self.tw.coord_scale = 1
             if self.tw.cartesian is True:
                 self.tw.overlay_shapes["Cartesian"].hide()
-                self.tw.overlay_shapes["Cartesian_labeled"].set_layer(OVERLAY_LAYER)
+                self.tw.overlay_shapes["Cartesian_labeled"].set_layer(
+                    OVERLAY_LAYER)
             default_values["forward"] = [100]
             default_values["back"] = [100]
             default_values["arc"] = [90, 100]
             default_values["setpensize"] = [5]
             self.tw.turtles.get_active_turtle().set_pen_size(5)
         if hasattr(self, "_settings"):
-            self._settings.set_int(self._COORDINATE_SCALE, int(self.tw.coord_scale))
+            self._settings.set_int(
+                self._COORDINATE_SCALE, int(self.tw.coord_scale))
 
         self.tw.recalculate_constants()
 
@@ -866,12 +875,15 @@ Would you like to save before quitting?"
             if button.get_active():
                 if name not in plugins:
                     plugins.append(name)
-                    self._settings.set_string(self._PLUGINS_LIST, ",".join(plugins))
-                label = _("Please restart %s in order to use the plugin.") % self.name
+                    self._settings.set_string(
+                        self._PLUGINS_LIST, ",".join(plugins))
+                label = _(
+                    "Please restart %s in order to use the plugin.") % self.name
             else:
                 if name in plugins:
                     plugins.remove(name)
-                    self._settings.set_string(self._PLUGINS_LIST, ",".join(plugins))
+                    self._settings.set_string(
+                        self._PLUGINS_LIST, ",".join(plugins))
                 label = (
                     _("Please restart %s in order to unload the plugin.") % self.name
                 )
@@ -987,7 +999,8 @@ Would you like to save before quitting?"
                 self.tw.paste_text_in_block_label(text)
                 self.tw.selected_blk.resize()
             else:
-                self.tw.process_data(data_from_string(text), self.tw.paste_offset)
+                self.tw.process_data(data_from_string(
+                    text), self.tw.paste_offset)
                 self.tw.paste_offset += PASTE_OFFSET
 
     def _do_about_cb(self, widget):
@@ -996,7 +1009,8 @@ Would you like to save before quitting?"
         about.set_version(self.version)
         about.set_comments(_(self.summary))
         about.set_website(self.website)
-        logo_path = os.path.join(self._share_path, "activity", self.icon_name + ".svg")
+        logo_path = os.path.join(
+            self._share_path, "activity", self.icon_name + ".svg")
         about.set_logo(GdkPixbuf.Pixbuf.new_from_file(logo_path))
         about.run()
         about.destroy()
@@ -1028,7 +1042,8 @@ Would you like to save before quitting?"
         """ From whence is the program being executed? """
         dirname = os.path.dirname(__file__)
         if dirname == "":
-            if os.path.exists(os.path.join("~", "Activities", "TurtleArt.activity")):
+            if os.path.exists(os.path.join(
+                    "~", "Activities", "TurtleArt.activity")):
                 return os.path.join("~", "Activities", "TurtleArt.activity")
             elif os.path.exists(self._INSTALL_PATH):
                 return self._INSTALL_PATH
@@ -1064,7 +1079,8 @@ Would you like to save before quitting?"
             icon_view = Gtk.IconView()
             icon_view.set_model(store)
             icon_view.set_selection_mode(Gtk.SelectionMode.SINGLE)
-            icon_view.connect("selection-changed", self._sample_selected, store)
+            icon_view.connect("selection-changed",
+                              self._sample_selected, store)
             icon_view.set_pixbuf_column(0)
             icon_view.grab_focus()
             self._sample_window.add_with_viewport(icon_view)
@@ -1111,7 +1127,8 @@ Would you like to save before quitting?"
         # Convert from thumbnail path to sample path
         basename = os.path.basename(self._selected_sample)[:-4]
         for suffix in [".ta", ".tb"]:
-            file_path = os.path.join(self._share_path, "samples", basename + suffix)
+            file_path = os.path.join(
+                self._share_path, "samples", basename + suffix)
             if os.path.exists(file_path):
                 self.tw.load_files(file_path)
                 break


### PR DESCRIPTION
Changes Made To Add Hollow Line Block


* taturtle:
Modified the forward, backward, arc, and setxy functions to support dual-mode operation via a wrapper. One mode retains the standard behavior, while the other introduces "hollow draw" functionality.

* tabasics:
Added the logic for the "Draw Hollow" button, and modified the behavior of forward, backward, arc, and setxy to handle hollow draw mode when enabled.

* talogo:
Introduced support for hollow drawing in forward. Added logic to manage custom attributes, including thickness and a boolean flag indicating whether hollow drawing is active. Drawing behavior is now conditionally executed based on this flag.

* tawindow:
Added a function to return self.lc, enabling external access to the talogo instance.

Link of the issue I'm trying to solve: [https://github.com/sugarlabs/turtleart-activity/issues/95](https://github.com/sugarlabs/turtleart-activity/issues/95)

@walterbender 
@chimosky 